### PR TITLE
Making sample composite identity more correct

### DIFF
--- a/alchemy-example/src/main/java/com/rtr/alchemy/example/LibraryExample.java
+++ b/alchemy-example/src/main/java/com/rtr/alchemy/example/LibraryExample.java
@@ -162,14 +162,14 @@ public class LibraryExample {
             // Experiment with composite identity - an identity where hashing can change based on what segments are requested
             experiments
                 .create("composite")
-                .setSegments(User.SEGMENT_IDENTIFIED, Composite.SEGMENT_DEVICE) // we want only users that are identified and we prefer to hash on device
+                .setSegments(User.SEGMENT_IDENTIFIED, Device.SEGMENT_DEVICE) // we want only users that are identified and we prefer to hash on device
                 .addTreatment("control")
                 .allocate("control", 100)
                 .activate()
                 .save();
 
             // These are the segments that will be requested by the experiment when calling computeHash
-            final Set<String> segments = Sets.newHashSet(User.SEGMENT_IDENTIFIED, Composite.SEGMENT_DEVICE);
+            final Set<String> segments = Sets.newHashSet(User.SEGMENT_IDENTIFIED, Device.SEGMENT_DEVICE);
 
             final Composite userOnly = new Composite(new User("foo"), null);
             println("treatment for user-only composite: %s", experiments.getActiveTreatment("composite", userOnly));

--- a/alchemy-example/src/main/java/com/rtr/alchemy/example/identities/Composite.java
+++ b/alchemy-example/src/main/java/com/rtr/alchemy/example/identities/Composite.java
@@ -10,13 +10,8 @@ import java.util.Set;
  * Demonstrates how one may do composite identities, which are complex identities which are made up of sub-identities
  * and have complex criteria for computing their hash
  */
-@Segments(
-    value = { Composite.SEGMENT_USER, Composite.SEGMENT_DEVICE },
-    identities = { User.class, Device.class }
-)
+@Segments(identities = { User.class, Device.class })
 public class Composite extends Identity {
-    public static final String SEGMENT_USER = "user";
-    public static final String SEGMENT_DEVICE = "device";
     private final User user;
     private final Device device;
 
@@ -40,9 +35,9 @@ public class Composite extends Identity {
         // if only device is specified, we hash device, if both are specified, we hash user.  If neither are
         // specified, we can return whichever is not null first user vs device
 
-        if (segments.contains(SEGMENT_USER)) { // "user" or "both" were requested
+        if (segments.contains(User.SEGMENT_USER)) { // "user" or "both" were requested
             return user.computeHash(seed, segments);
-        } else if (segments.contains(SEGMENT_DEVICE)) { // "device" was requested
+        } else if (segments.contains(Device.SEGMENT_DEVICE)) { // "device" was requested
             return device.computeHash(seed, segments);
         }
 
@@ -62,14 +57,8 @@ public class Composite extends Identity {
     public Set<String> computeSegments() {
         return
             Sets.union(
-                segments(
-                    user != null ? "user" : null,
-                    device != null ? "device" : null
-                ),
-                Sets.union(
-                    segments(user),
-                    segments(device)
-                )
+                segments(user),
+                segments(device)
             );
     }
 }

--- a/alchemy-example/src/main/java/com/rtr/alchemy/example/identities/Device.java
+++ b/alchemy-example/src/main/java/com/rtr/alchemy/example/identities/Device.java
@@ -1,10 +1,13 @@
 package com.rtr.alchemy.example.identities;
 
 import com.rtr.alchemy.identities.Identity;
+import com.rtr.alchemy.identities.Segments;
 
 import java.util.Set;
 
+@Segments(Device.SEGMENT_DEVICE)
 public class Device extends Identity {
+    public static final String SEGMENT_DEVICE = "device";
     private final String id;
 
     public Device(String id) {
@@ -21,5 +24,10 @@ public class Device extends Identity {
             identity(seed)
                 .putString(id)
                 .hash();
+    }
+
+    @Override
+    public Set<String> computeSegments() {
+        return segments(SEGMENT_DEVICE);
     }
 }

--- a/alchemy-example/src/main/java/com/rtr/alchemy/example/identities/User.java
+++ b/alchemy-example/src/main/java/com/rtr/alchemy/example/identities/User.java
@@ -8,10 +8,12 @@ import java.util.Set;
 /**
  * An example identity
  */
-@Segments({User.SEGMENT_ANONYMOUS, User.SEGMENT_IDENTIFIED})
+@Segments({User.SEGMENT_USER, User.SEGMENT_ANONYMOUS, User.SEGMENT_IDENTIFIED})
 public class User extends Identity {
     public static final String SEGMENT_ANONYMOUS = "anonymous";
     public static final String SEGMENT_IDENTIFIED = "identified";
+    public static final String SEGMENT_USER = "user";
+
     private final String name;
 
     public User(String name) {
@@ -31,6 +33,6 @@ public class User extends Identity {
 
     @Override
     public Set<String> computeSegments() {
-        return segments(name == null ? SEGMENT_ANONYMOUS : SEGMENT_IDENTIFIED);
+        return segments(SEGMENT_USER, name == null ? SEGMENT_ANONYMOUS : SEGMENT_IDENTIFIED);
     }
 }


### PR DESCRIPTION
Minor update: I'm moving the returning of "user" and "device" segments to the respective identity classes, this way if you had an experiment that required segment "user", you could still pass in User by itself rather than the Composite of User+Device, and it would still match in this case.  The interesting example is that if you passed in just Device for an experiment that required "identified" which comes from User and "device" which comes from Device, you still would not receive a treatment because with Device alone you cannot be "identified", unless Device itself also returned that segment.
