### PR TITLE
INFRA-1305: Make faled loading of experiments more resilient

### DIFF
--- a/alchemy-db-mongo/pom.xml
+++ b/alchemy-db-mongo/pom.xml
@@ -30,6 +30,10 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/alchemy-db-mongo/src/main/java/com/rtr/alchemy/db/mongo/util/ExceptionSafeIterator.java
+++ b/alchemy-db-mongo/src/main/java/com/rtr/alchemy/db/mongo/util/ExceptionSafeIterator.java
@@ -1,0 +1,65 @@
+package com.rtr.alchemy.db.mongo.util;
+
+import com.google.common.collect.AbstractIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+
+/**
+ * Ensures that if there's a problem loading an entity that we don't fail loading the rest but instead just skip over it
+ * @param <T> The type of thing we're iterating over
+ */
+public class ExceptionSafeIterator<T> implements Iterator<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(ExceptionSafeIterator.class);
+    private final Iterator<T> abstractIterator;
+    private final Iterator<T> iterator;
+    private boolean nextCalled;
+
+    private ExceptionSafeIterator(final Iterator<T> iterator) {
+        this.abstractIterator = new AbstractIterator<T>() {
+            @Override
+            protected T computeNext() {
+                while(iterator.hasNext()) {
+                    try {
+                        return iterator.next();
+                    } catch (Exception e) {
+                        LOG.error("failed to retrieve next item from iterator, skipping item", e);
+                    }
+                }
+
+                return endOfData();
+            }
+        };
+        this.iterator = iterator;
+    }
+
+    public static <T> ExceptionSafeIterator<T> wrap(Iterator<T> iterator) {
+        return new ExceptionSafeIterator<>(iterator);
+    }
+
+    @Override
+    public boolean hasNext() {
+        nextCalled = false;
+        return abstractIterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+        nextCalled = true;
+        return abstractIterator.next();
+    }
+
+    // AbstractIterator<T> doesn't support remove(), because it peeks ahead and can cause ambiguity as to which element
+    // is being removed.  Here we make a compromise where assuming that next() has been called after a hasNext(), which
+    // is the most common use case, we can safely call remove()
+    @Override
+    public void remove() {
+        if (!nextCalled) {
+            // because elements are peeked in advanced, to avoid confusion as to which element is being been removed
+            // one must first call next() after calling hasNext() before being able to call remove()
+            throw new UnsupportedOperationException("cannot remove element until next() has been called after calling hasNext()");
+        }
+        iterator.remove();
+    }
+}

--- a/alchemy-db-mongo/src/main/java/com/rtr/alchemy/db/mongo/util/ExperimentIterable.java
+++ b/alchemy-db-mongo/src/main/java/com/rtr/alchemy/db/mongo/util/ExperimentIterable.java
@@ -19,22 +19,24 @@ public class ExperimentIterable implements Iterable<Experiment> {
 
     @Override
     public Iterator<Experiment> iterator() {
-        return new Iterator<Experiment>() {
-            @Override
-            public boolean hasNext() {
-                return iterator.hasNext();
-            }
+        return ExceptionSafeIterator.wrap(
+            new Iterator<Experiment>() {
+                @Override
+                public boolean hasNext() {
+                    return iterator.hasNext();
+                }
 
-            @Override
-            public Experiment next() {
-                final ExperimentEntity entity = iterator.next();
-                return entity.toExperiment(factory.createBuilder(entity.name));
-            }
+                @Override
+                public Experiment next() {
+                    final ExperimentEntity entity = iterator.next();
+                    return entity.toExperiment(factory.createBuilder(entity.name));
+                }
 
-            @Override
-            public void remove() {
-                iterator.remove();
+                @Override
+                public void remove() {
+                    iterator.remove();
+                }
             }
-        };
+        );
     }
 }

--- a/alchemy-db-mongo/src/test/java/com/rtr/alchemy/db/mongo/util/ExceptionSafeIteratorTest.java
+++ b/alchemy-db-mongo/src/test/java/com/rtr/alchemy/db/mongo/util/ExceptionSafeIteratorTest.java
@@ -1,0 +1,75 @@
+package com.rtr.alchemy.db.mongo.util;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ExceptionSafeIteratorTest {
+    @Test
+    public void testIteratorWithExceptions() {
+        final Iterator<Integer> throwIterator = new Iterator<Integer>() {
+            private final Integer[] numbers = { 0, 1, null, 2, null, null, 3, null, null };
+            private int n = 0;
+
+            @Override
+            public boolean hasNext() {
+                return n < numbers.length;
+            }
+
+            @Override
+            public Integer next() {
+                if (numbers[n] == null) {
+                    n++;
+                    throw new UnsupportedOperationException();
+                }
+
+                return numbers[n++];
+            }
+
+            @Override
+            public void remove() {
+            }
+        };
+
+        final Iterator<Integer> evens = ExceptionSafeIterator.wrap(throwIterator);
+
+        assertArrayEquals(new Integer[]{0, 1, 2, 3}, Iterators.toArray(evens, Integer.class));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testIteratorExhausted() {
+        final Iterator<Integer> emptyIterator = ExceptionSafeIterator.wrap(Collections.<Integer>emptyIterator());
+        assertFalse(emptyIterator.hasNext());
+        emptyIterator.next();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIteratorRemoveWithoutNext() {
+        final Iterator<Integer> iterator = ExceptionSafeIterator.wrap(Lists.newArrayList(1, 2, 3).iterator());
+        assertTrue(iterator.hasNext());
+        iterator.next();
+        assertTrue(iterator.hasNext());
+        iterator.remove();
+    }
+
+    @Test
+    public void testIteratorRemove() {
+        final List<Integer> numbers = Lists.newArrayList(1, 2, 3);
+        final Iterator<Integer> iterator = ExceptionSafeIterator.wrap(numbers.iterator());
+        assertTrue(iterator.hasNext());
+        iterator.next();
+        iterator.remove();
+
+        assertEquals(Lists.newArrayList(2, 3), numbers);
+    }
+}


### PR DESCRIPTION
Right now, if for some reason an experiment can't be loaded from MongoDB (e.g. bad format, etc.), it causes all other experiments to fail to load and also prevents the store provider from initializing

This PR will instead log an error when a given experiment failed to be loaded and will continue loading the rest.
