### PR TITLE
Replace checkState for checkArgument and remove illegalstateexception from runtimexceptionmapper

### DIFF
--- a/alchemy-core/src/main/java/io/rtr/alchemy/models/Allocations.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/models/Allocations.java
@@ -121,7 +121,7 @@ public class Allocations {
      * @param size The number of bins
      */
     public void allocate(Treatment treatment, int size) {
-        Preconditions.checkState(
+        Preconditions.checkArgument(
             getUnallocatedSize() >= size,
             "not enough free bins to allocate treatment %s with size %s given %s unallocated bin(s)",
             treatment.getName(),

--- a/alchemy-core/src/main/java/io/rtr/alchemy/models/Experiment.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/models/Experiment.java
@@ -380,7 +380,7 @@ public class Experiment implements Named {
 
     private Treatment treatment(String name) {
         final Treatment treatment = treatments.get(name);
-        Preconditions.checkState(treatment != null, "no treatment with name %s defined", name);
+        Preconditions.checkArgument(treatment != null, "no treatment with name %s defined", name);
         return treatment;
     }
 
@@ -589,7 +589,7 @@ public class Experiment implements Named {
 
         private Treatment getTreatment(String name) {
             final Treatment treatment = treatments.get(name);
-            Preconditions.checkState(treatment != null, "treatment with name %s must be defined first", name);
+            Preconditions.checkArgument(treatment != null, "treatment with name %s must be defined first", name);
             return treatment;
         }
 

--- a/alchemy-core/src/test/java/io/rtr/alchemy/models/AllocationsTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/models/AllocationsTest.java
@@ -92,7 +92,7 @@ public class AllocationsTest {
         new Allocations(allocationList);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testAllocatingTooMuch() {
         final Allocations allocations = new Allocations(Lists.<Allocation>newArrayList());
         allocations.allocate(control, Allocations.NUM_BINS + 1);

--- a/alchemy-mapping/src/main/java/io/rtr/alchemy/mapping/Mappers.java
+++ b/alchemy-mapping/src/main/java/io/rtr/alchemy/mapping/Mappers.java
@@ -60,7 +60,7 @@ public class Mappers {
 
         final Mapper mapper = bySourceType.get(destType);
 
-        Preconditions.checkState(
+        Preconditions.checkArgument(
             mapper != null,
             "No mapper defined from type %s to type %s",
             sourceType,

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/exceptions/RuntimeExceptionMapper.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/exceptions/RuntimeExceptionMapper.java
@@ -20,7 +20,6 @@ public class RuntimeExceptionMapper implements ExceptionMapper<RuntimeException>
         // 400 - Bad Request
         register(Response.Status.BAD_REQUEST,
             IllegalArgumentException.class,
-            IllegalStateException.class,
             NullPointerException.class
         );
     }


### PR DESCRIPTION
Since DW13, IllegalStateExceptionMapper is separated from the RuntimeExceptionMapper