### PR TITLE
INF-2459 Nexus plugin should be used by child POMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,6 @@
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.8</version>
                         <extensions>true</extensions>
-                        <inherited>false</inherited>
                         <configuration>
                             <serverId>sonatype-nexus-staging</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>


### PR DESCRIPTION
I believe that enabling plugin inheritance for the child modules should resolve our issues with deploying them to Sonatype.