### PR TITLE
READLY-123 Bump and clean up plugins; apply Google Java Format

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,501 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="100" />
+    <JavaCodeStyleSettings>
+      <option name="GENERATE_FINAL_LOCALS" value="true" />
+      <option name="GENERATE_FINAL_PARAMETERS" value="true" />
+      <option name="REPLACE_INSTANCEOF_AND_CAST" value="true" />
+      <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+        </value>
+      </option>
+      <option name="JD_KEEP_INVALID_TAGS" value="false" />
+      <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+    </JavaCodeStyleSettings>
+    <XML>
+      <option name="XML_ALIGN_ATTRIBUTES" value="false" />
+    </XML>
+    <codeStyleSettings language="CSS">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="ECMA Script Level 4">
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    </codeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="0" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="THROWS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="WRAP_COMMENTS" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+    </codeStyleSettings>
+    <codeStyleSettings language="JSON">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="RIGHT_MARGIN" value="80" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="ObjectiveC">
+      <option name="RIGHT_MARGIN" value="80" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="BLANK_LINES_BEFORE_IMPORTS" value="0" />
+      <option name="BLANK_LINES_AFTER_IMPORTS" value="0" />
+      <option name="BLANK_LINES_AROUND_CLASS" value="0" />
+      <option name="BLANK_LINES_AROUND_METHOD" value="0" />
+      <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="PROTO">
+      <option name="RIGHT_MARGIN" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Python">
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="RIGHT_MARGIN" value="80" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="SASS">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="SCSS">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:.*Style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_width</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_height</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_weight</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_margin</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginTop</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginBottom</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginStart</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginEnd</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginLeft</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginRight</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:padding</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingTop</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingBottom</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingStart</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingEnd</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingLeft</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingRight</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/tools</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="protobuf">
+      <option name="RIGHT_MARGIN" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="google-java-format" />
+  </component>
+</project>

--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="true" />
+    <option name="style" value="AOSP" />
+  </component>
+</project>

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/identities/Identities.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/identities/Identities.java
@@ -3,13 +3,11 @@ package io.rtr.alchemy.dto.identities;
 import java.util.ArrayList;
 import java.util.Collections;
 
-/**
- * We need this class to deal with Jackson List serialization issues due to type-erasure
- */
-public class Identities  extends ArrayList<IdentityDto> {
+/** We need this class to deal with Jackson List serialization issues due to type-erasure */
+public class Identities extends ArrayList<IdentityDto> {
     private static final long serialVersionUID = 8406201398658647047L;
 
-    public static Identities of(IdentityDto ... requests) {
+    public static Identities of(IdentityDto... requests) {
         final Identities result = new Identities();
         Collections.addAll(result, requests);
         return result;
@@ -19,4 +17,3 @@ public class Identities  extends ArrayList<IdentityDto> {
         return new Identities();
     }
 }
-

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/identities/IdentityDto.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/identities/IdentityDto.java
@@ -2,9 +2,6 @@ package io.rtr.alchemy.dto.identities;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-/**
- * Represents an identity which other identity DTOs must extend
- */
+/** Represents an identity which other identity DTOs must extend */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-public abstract class IdentityDto {
-}
+public abstract class IdentityDto {}

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/models/AllocationDto.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/models/AllocationDto.java
@@ -4,18 +4,17 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 
-/**
- * Represents an allocation
- */
+/** Represents an allocation */
 public class AllocationDto {
     private final String treatment;
     private final int offset;
     private final int size;
 
     @JsonCreator
-    public AllocationDto(@JsonProperty("treatment") String treatment,
-                         @JsonProperty("offset") int offset,
-                         @JsonProperty("size") int size) {
+    public AllocationDto(
+            @JsonProperty("treatment") String treatment,
+            @JsonProperty("offset") int offset,
+            @JsonProperty("size") int size) {
         this.treatment = treatment;
         this.offset = offset;
         this.size = size;
@@ -46,9 +45,8 @@ public class AllocationDto {
 
         final AllocationDto other = (AllocationDto) obj;
 
-        return
-            Objects.equal(treatment, other.treatment) &&
-            Objects.equal(offset, other.offset) &&
-            Objects.equal(size, other.size);
+        return Objects.equal(treatment, other.treatment)
+                && Objects.equal(offset, other.offset)
+                && Objects.equal(size, other.size);
     }
 }

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/models/ExperimentDto.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/models/ExperimentDto.java
@@ -8,9 +8,7 @@ import org.joda.time.DateTime;
 import java.util.List;
 import java.util.Set;
 
-/**
- * Represents an experiment
- */
+/** Represents an experiment */
 public class ExperimentDto {
     private final String name;
     private final int seed;
@@ -27,19 +25,20 @@ public class ExperimentDto {
     private final List<TreatmentOverrideDto> overrides;
 
     @JsonCreator
-    public ExperimentDto(@JsonProperty("name") String name,
-                         @JsonProperty("seed") int seed,
-                         @JsonProperty("description") String description,
-                         @JsonProperty("filter") String filter,
-                         @JsonProperty("hashAttributes") Set<String> hashAttributes,
-                         @JsonProperty("active") boolean active,
-                         @JsonProperty("created") DateTime created,
-                         @JsonProperty("modified") DateTime modified,
-                         @JsonProperty("activated") DateTime activated,
-                         @JsonProperty("deactivated") DateTime deactivated,
-                         @JsonProperty("treatments") List<TreatmentDto> treatments,
-                         @JsonProperty("allocations") List<AllocationDto> allocations,
-                         @JsonProperty("overrides") List<TreatmentOverrideDto> overrides) {
+    public ExperimentDto(
+            @JsonProperty("name") String name,
+            @JsonProperty("seed") int seed,
+            @JsonProperty("description") String description,
+            @JsonProperty("filter") String filter,
+            @JsonProperty("hashAttributes") Set<String> hashAttributes,
+            @JsonProperty("active") boolean active,
+            @JsonProperty("created") DateTime created,
+            @JsonProperty("modified") DateTime modified,
+            @JsonProperty("activated") DateTime activated,
+            @JsonProperty("deactivated") DateTime deactivated,
+            @JsonProperty("treatments") List<TreatmentDto> treatments,
+            @JsonProperty("allocations") List<AllocationDto> allocations,
+            @JsonProperty("overrides") List<TreatmentOverrideDto> overrides) {
         this.name = name;
         this.seed = seed;
         this.description = description;

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/models/TreatmentDto.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/models/TreatmentDto.java
@@ -6,17 +6,14 @@ import com.google.common.base.Objects;
 
 import javax.validation.constraints.NotNull;
 
-/**
- * Represents a treatment
- */
+/** Represents a treatment */
 public class TreatmentDto {
-    @NotNull
-    private final String name;
+    @NotNull private final String name;
     private final String description;
 
     @JsonCreator
-    public TreatmentDto(@JsonProperty("name") String name,
-                        @JsonProperty("description") String description) {
+    public TreatmentDto(
+            @JsonProperty("name") String name, @JsonProperty("description") String description) {
         this.name = name;
         this.description = description;
     }
@@ -42,7 +39,6 @@ public class TreatmentDto {
 
         final TreatmentDto other = (TreatmentDto) obj;
 
-        return
-            Objects.equal(name, other.name);
+        return Objects.equal(name, other.name);
     }
 }

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/models/TreatmentOverrideDto.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/models/TreatmentOverrideDto.java
@@ -3,17 +3,16 @@ package io.rtr.alchemy.dto.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 
-/**
- * Represents a treatment override
- */
+/** Represents a treatment override */
 public class TreatmentOverrideDto {
     private final String name;
     private final String filter;
     private final String treatment;
 
-    public TreatmentOverrideDto(@JsonProperty("name") String name,
-                                @JsonProperty("filter") String filter,
-                                @JsonProperty("treatment") String treatment) {
+    public TreatmentOverrideDto(
+            @JsonProperty("name") String name,
+            @JsonProperty("filter") String filter,
+            @JsonProperty("treatment") String treatment) {
         this.name = name;
         this.filter = filter;
         this.treatment = treatment;
@@ -43,9 +42,8 @@ public class TreatmentOverrideDto {
         }
 
         final TreatmentOverrideDto other = (TreatmentOverrideDto) obj;
-        return
-            Objects.equal(name, other.name) &&
-            Objects.equal(filter, other.filter) &&
-            Objects.equal(treatment, other.treatment);
+        return Objects.equal(name, other.name)
+                && Objects.equal(filter, other.filter)
+                && Objects.equal(treatment, other.treatment);
     }
 }

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/AllocateRequest.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/AllocateRequest.java
@@ -4,17 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
 
-/**
- * Represents a simple allocation request
- */
+/** Represents a simple allocation request */
 public class AllocateRequest {
-    @NotNull
-    private final String treatment;
-    @NotNull
-    private final Integer size;
+    @NotNull private final String treatment;
+    @NotNull private final Integer size;
 
-    public AllocateRequest(@JsonProperty("treatment") String treatment,
-                           @JsonProperty("size") Integer size) {
+    public AllocateRequest(
+            @JsonProperty("treatment") String treatment, @JsonProperty("size") Integer size) {
         this.treatment = treatment;
         this.size = size;
     }

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/AllocationRequest.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/AllocationRequest.java
@@ -8,9 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import javax.validation.constraints.NotNull;
 
-/**
- * Represents requests for multiple allocation actions
- */
+/** Represents requests for multiple allocation actions */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "action")
 @JsonSubTypes({
     @Type(AllocationRequest.Reallocate.class),
@@ -18,13 +16,10 @@ import javax.validation.constraints.NotNull;
     @Type(AllocationRequest.Deallocate.class)
 })
 public abstract class AllocationRequest {
-    @NotNull
-    private final String treatment;
-    @NotNull
-    private final Integer size;
+    @NotNull private final String treatment;
+    @NotNull private final Integer size;
 
-    public AllocationRequest(String treatment,
-                             Integer size) {
+    public AllocationRequest(String treatment, Integer size) {
         this.treatment = treatment;
         this.size = size;
     }
@@ -39,28 +34,28 @@ public abstract class AllocationRequest {
 
     @JsonTypeName("allocate")
     public static class Allocate extends AllocationRequest {
-        public Allocate(@JsonProperty("treatment") String treatment,
-                        @JsonProperty("size") Integer size) {
+        public Allocate(
+                @JsonProperty("treatment") String treatment, @JsonProperty("size") Integer size) {
             super(treatment, size);
         }
     }
 
     @JsonTypeName("deallocate")
     public static class Deallocate extends AllocationRequest {
-        public Deallocate(@JsonProperty("treatment") String treatment,
-                          @JsonProperty("size") Integer size) {
+        public Deallocate(
+                @JsonProperty("treatment") String treatment, @JsonProperty("size") Integer size) {
             super(treatment, size);
         }
     }
 
     @JsonTypeName("reallocate")
     public static class Reallocate extends AllocationRequest {
-        @NotNull
-        private final String target;
+        @NotNull private final String target;
 
-        public Reallocate(@JsonProperty("treatment") String treatment,
-                          @JsonProperty("size") Integer size,
-                          @JsonProperty("target") String target) {
+        public Reallocate(
+                @JsonProperty("treatment") String treatment,
+                @JsonProperty("size") Integer size,
+                @JsonProperty("target") String target) {
             super(treatment, size);
             this.target = target;
         }

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/AllocationRequests.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/AllocationRequests.java
@@ -3,13 +3,11 @@ package io.rtr.alchemy.dto.requests;
 import java.util.ArrayList;
 import java.util.Collections;
 
-/**
- * We need this class to deal with Jackson List serialization issues due to type-erasure
- */
+/** We need this class to deal with Jackson List serialization issues due to type-erasure */
 public class AllocationRequests extends ArrayList<AllocationRequest> {
     private static final long serialVersionUID = 3619787346944661924L;
 
-    public static AllocationRequests of(AllocationRequest ... requests) {
+    public static AllocationRequests of(AllocationRequest... requests) {
         final AllocationRequests result = new AllocationRequests();
         Collections.addAll(result, requests);
         return result;

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/CreateExperimentRequest.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/CreateExperimentRequest.java
@@ -8,33 +8,28 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Set;
 
-/**
- * Represents a request for creating an experiment
- */
+/** Represents a request for creating an experiment */
 public class CreateExperimentRequest {
-    @NotNull
-    private final String name;
+    @NotNull private final String name;
     private final Integer seed;
     private final String description;
     private final String filter;
     private final Set<String> hashAttributes;
     private final Boolean active;
-    @Valid
-    private final List<TreatmentDto> treatments;
-    @Valid
-    private final List<AllocateRequest> allocations;
-    @Valid
-    private final List<TreatmentOverrideRequest> overrides;
+    @Valid private final List<TreatmentDto> treatments;
+    @Valid private final List<AllocateRequest> allocations;
+    @Valid private final List<TreatmentOverrideRequest> overrides;
 
-    public CreateExperimentRequest(@JsonProperty("name") String name,
-                                   @JsonProperty("seed") Integer seed,
-                                   @JsonProperty("description") String description,
-                                   @JsonProperty("filter") String filter,
-                                   @JsonProperty("hashAttributes") Set<String> hashAttributes,
-                                   @JsonProperty("active") Boolean active,
-                                   @JsonProperty("treatments") List<TreatmentDto> treatments,
-                                   @JsonProperty("allocations") List<AllocateRequest> allocations,
-                                   @JsonProperty("overrides") List<TreatmentOverrideRequest> overrides) {
+    public CreateExperimentRequest(
+            @JsonProperty("name") String name,
+            @JsonProperty("seed") Integer seed,
+            @JsonProperty("description") String description,
+            @JsonProperty("filter") String filter,
+            @JsonProperty("hashAttributes") Set<String> hashAttributes,
+            @JsonProperty("active") Boolean active,
+            @JsonProperty("treatments") List<TreatmentDto> treatments,
+            @JsonProperty("allocations") List<AllocateRequest> allocations,
+            @JsonProperty("overrides") List<TreatmentOverrideRequest> overrides) {
         this.name = name;
         this.seed = seed;
         this.description = description;
@@ -56,8 +51,8 @@ public class CreateExperimentRequest {
 
     public String getDescription() {
         return description;
-
     }
+
     public String getFilter() {
         return filter;
     }

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/GetExperimentsRequest.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/GetExperimentsRequest.java
@@ -1,9 +1,6 @@
 package io.rtr.alchemy.dto.requests;
 
-/**
- * Represents a request for getting filtered experiment
- */
-
+/** Represents a request for getting filtered experiment */
 public class GetExperimentsRequest {
     private final String filter;
     private final Integer offset;

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/TreatmentOverrideRequest.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/TreatmentOverrideRequest.java
@@ -4,20 +4,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
 
-/**
- * Represents a request for creating an override
- */
+/** Represents a request for creating an override */
 public class TreatmentOverrideRequest {
-    @NotNull
-    private final String treatment;
-    @NotNull
-    private final String filter;
-    @NotNull
-    private final String name;
+    @NotNull private final String treatment;
+    @NotNull private final String filter;
+    @NotNull private final String name;
 
-    public TreatmentOverrideRequest(@JsonProperty("treatment") String treatment,
-                                    @JsonProperty("filter") String filter,
-                                    @JsonProperty("name") String name) {
+    public TreatmentOverrideRequest(
+            @JsonProperty("treatment") String treatment,
+            @JsonProperty("filter") String filter,
+            @JsonProperty("name") String name) {
         this.treatment = treatment;
         this.filter = filter;
         this.name = name;

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/UpdateExperimentRequest.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/UpdateExperimentRequest.java
@@ -7,9 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-/**
- * Represents a request for updating an experiment
- */
+/** Represents a request for updating an experiment */
 public class UpdateExperimentRequest {
     private Optional<Integer> seed;
     private Optional<String> description;
@@ -17,25 +15,23 @@ public class UpdateExperimentRequest {
     private Optional<Set<String>> hashAttributes;
     private Optional<Boolean> active;
 
-    @Valid
-    private Optional<List<TreatmentDto>> treatments;
+    @Valid private Optional<List<TreatmentDto>> treatments;
 
-    @Valid
-    private Optional<List<AllocateRequest>> allocations;
+    @Valid private Optional<List<AllocateRequest>> allocations;
 
-    @Valid
-    private Optional<List<TreatmentOverrideRequest>> overrides;
+    @Valid private Optional<List<TreatmentOverrideRequest>> overrides;
 
-    public UpdateExperimentRequest() { }
+    public UpdateExperimentRequest() {}
 
-    public UpdateExperimentRequest(Optional<Integer> seed,
-                                   Optional<String> description,
-                                   Optional<String> filter,
-                                   Optional<Set<String>> hashAttributes,
-                                   Optional<Boolean> active,
-                                   Optional<List<TreatmentDto>> treatments,
-                                   Optional<List<AllocateRequest>> allocations,
-                                   Optional<List<TreatmentOverrideRequest>> overrides) {
+    public UpdateExperimentRequest(
+            Optional<Integer> seed,
+            Optional<String> description,
+            Optional<String> filter,
+            Optional<Set<String>> hashAttributes,
+            Optional<Boolean> active,
+            Optional<List<TreatmentDto>> treatments,
+            Optional<List<AllocateRequest>> allocations,
+            Optional<List<TreatmentOverrideRequest>> overrides) {
         this.seed = seed;
         this.description = description;
         this.filter = filter;
@@ -45,6 +41,7 @@ public class UpdateExperimentRequest {
         this.allocations = allocations;
         this.overrides = overrides;
     }
+
     public Optional<Integer> getSeed() {
         return seed;
     }

--- a/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/UpdateTreatmentRequest.java
+++ b/alchemy-api/src/main/java/io/rtr/alchemy/dto/requests/UpdateTreatmentRequest.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 public class UpdateTreatmentRequest {
     private Optional<String> description;
 
-    public UpdateTreatmentRequest() { }
+    public UpdateTreatmentRequest() {}
 
     public UpdateTreatmentRequest(Optional<String> description) {
         this.description = description;

--- a/alchemy-api/src/test/java/io/rtr/alchemy/dto/JsonSerializationDeserializationTest.java
+++ b/alchemy-api/src/test/java/io/rtr/alchemy/dto/JsonSerializationDeserializationTest.java
@@ -40,8 +40,9 @@ public class JsonSerializationDeserializationTest {
     }
 
     /**
-     * This method will test whether the give json deserializes into the given object and whether the given
-     * object serializes into the given json
+     * This method will test whether the give json deserializes into the given object and whether
+     * the given object serializes into the given json
+     *
      * @param value The object to test
      * @param resourceFile The file that contains the json to compare with
      */
@@ -50,74 +51,69 @@ public class JsonSerializationDeserializationTest {
         final JsonNode objectTree = mapper.valueToTree(value);
 
         try {
-            assertEquals(mapper.readTree(jsonTree.toString()),  mapper.readTree(objectTree.toString()));
+            assertEquals(
+                    mapper.readTree(jsonTree.toString()), mapper.readTree(objectTree.toString()));
         } catch (IOException e) {
             fail(e.getMessage());
         }
     }
 
     private void assertJson(Object value) {
-        final Class<?> clazz = value.getClass().isAnonymousClass() ? value.getClass().getSuperclass() : value.getClass();
+        final Class<?> clazz =
+                value.getClass().isAnonymousClass()
+                        ? value.getClass().getSuperclass()
+                        : value.getClass();
         assertJson(value, clazz.getSimpleName() + ".json");
     }
 
     private JsonNode readTreeFromResource(String resourceFile) {
-        final InputStream stream = JsonSerializationDeserializationTest.class.getClassLoader().getResourceAsStream(resourceFile);
+        final InputStream stream =
+                JsonSerializationDeserializationTest.class
+                        .getClassLoader()
+                        .getResourceAsStream(resourceFile);
         assertNotNull(String.format("could not load resource file %s", resourceFile), stream);
 
         try {
             return mapper.readTree(stream);
         } catch (final IOException e) {
             throw new AssertionError(
-                String.format(
-                    "could not parse json from resource file %s: %s",
-                    resourceFile,
-                    e.getMessage()
-                )
-            );
+                    String.format(
+                            "could not parse json from resource file %s: %s",
+                            resourceFile, e.getMessage()));
         } finally {
-            try { stream.close(); } catch (final IOException ignored) { }
+            try {
+                stream.close();
+            } catch (final IOException ignored) {
+            }
         }
     }
 
     @Test
     public void testAllocationDto() {
-        assertJson(new AllocationDto(
-            "control",
-            20,
-            10
-        ));
+        assertJson(new AllocationDto("control", 20, 10));
     }
 
     @Test
     public void testExperimentDto() {
-        assertJson(new ExperimentDto(
-            "my_experiment",
-            0,
-            "my new experiment",
-            "identified",
-            Sets.<String>newLinkedHashSet(),
-            true,
-            new DateTime(0),
-            new DateTime(1),
-            new DateTime(2),
-            new DateTime(3),
-            Lists.newArrayList(
-                new TreatmentDto("control", "the base case"),
-                new TreatmentDto("x", "some other condition")
-            ),
-            Lists.newArrayList(
-                new AllocationDto("control", 0, 5),
-                new AllocationDto("x", 5, 10)
-            ),
-            Lists.newArrayList(
-                new TreatmentOverrideDto(
-                    "qa_override",
-                    "true",
-                    "control"
-                )
-            )
-        ));
+        assertJson(
+                new ExperimentDto(
+                        "my_experiment",
+                        0,
+                        "my new experiment",
+                        "identified",
+                        Sets.<String>newLinkedHashSet(),
+                        true,
+                        new DateTime(0),
+                        new DateTime(1),
+                        new DateTime(2),
+                        new DateTime(3),
+                        Lists.newArrayList(
+                                new TreatmentDto("control", "the base case"),
+                                new TreatmentDto("x", "some other condition")),
+                        Lists.newArrayList(
+                                new AllocationDto("control", 0, 5), new AllocationDto("x", 5, 10)),
+                        Lists.newArrayList(
+                                new TreatmentOverrideDto("qa_override", "true", "control"))));
     }
 
     @Test
@@ -127,13 +123,7 @@ public class JsonSerializationDeserializationTest {
 
     @Test
     public void testTreatmentOverrideDto() {
-        assertJson(
-            new TreatmentOverrideDto(
-                "qa_override",
-                "true",
-                "control"
-            )
-        );
+        assertJson(new TreatmentOverrideDto("qa_override", "true", "control"));
     }
 
     @JsonTypeName("mock")
@@ -169,67 +159,47 @@ public class JsonSerializationDeserializationTest {
     @Test
     public void testCreateExperimentRequest() {
         assertJson(
-            new CreateExperimentRequest(
-                "my_experiment",
-                0,
-                "my new experiment",
-                "identified",
-                Sets.<String>newLinkedHashSet(),
-                true,
-                Lists.newArrayList(
-                    new TreatmentDto("control", "the base case"),
-                    new TreatmentDto("x", "some other condition")
-                ),
-                Lists.newArrayList(
-                        new AllocateRequest("control", 5),
-                        new AllocateRequest("x", 10)
-                ),
-                Lists.newArrayList(
-                    new TreatmentOverrideRequest("control", "foo", "qa_override")
-                )
-            )
-        );
+                new CreateExperimentRequest(
+                        "my_experiment",
+                        0,
+                        "my new experiment",
+                        "identified",
+                        Sets.<String>newLinkedHashSet(),
+                        true,
+                        Lists.newArrayList(
+                                new TreatmentDto("control", "the base case"),
+                                new TreatmentDto("x", "some other condition")),
+                        Lists.newArrayList(
+                                new AllocateRequest("control", 5), new AllocateRequest("x", 10)),
+                        Lists.newArrayList(
+                                new TreatmentOverrideRequest("control", "foo", "qa_override"))));
     }
 
     @Test
     public void testTreatmentOverrideRequest() {
-        assertJson(
-            new TreatmentOverrideRequest(
-                "control",
-                "foo",
-                "qa_override"
-            )
-        );
+        assertJson(new TreatmentOverrideRequest("control", "foo", "qa_override"));
     }
 
     @Test
     public void testUpdateExperimentRequest() {
         assertJson(
-            new UpdateExperimentRequest(
-                    Optional.empty(),
-                    Optional.of("my new experiment"),
-                    Optional.of("identified"),
-                    Optional.<Set<String>>of(Sets.<String>newLinkedHashSet()),
-                    Optional.of(true),
-                    Optional.<List<TreatmentDto>>of(
-                        Lists.newArrayList(
-                            new TreatmentDto("control", "the base case"),
-                            new TreatmentDto("x", "some other condition")
-                        )
-                    ),
-                    Optional.<List<AllocateRequest>>of(
-                        Lists.newArrayList(
-                            new AllocateRequest("control", 5),
-                            new AllocateRequest("x", 10)
-                        )
-                    ),
-                    Optional.<List<TreatmentOverrideRequest>>of(
-                        Lists.newArrayList(
-                            new TreatmentOverrideRequest("control", "foo", "qa_override")
-                        )
-                    )
-            )
-        );
+                new UpdateExperimentRequest(
+                        Optional.empty(),
+                        Optional.of("my new experiment"),
+                        Optional.of("identified"),
+                        Optional.<Set<String>>of(Sets.<String>newLinkedHashSet()),
+                        Optional.of(true),
+                        Optional.<List<TreatmentDto>>of(
+                                Lists.newArrayList(
+                                        new TreatmentDto("control", "the base case"),
+                                        new TreatmentDto("x", "some other condition"))),
+                        Optional.<List<AllocateRequest>>of(
+                                Lists.newArrayList(
+                                        new AllocateRequest("control", 5),
+                                        new AllocateRequest("x", 10))),
+                        Optional.<List<TreatmentOverrideRequest>>of(
+                                Lists.newArrayList(
+                                        new TreatmentOverrideRequest(
+                                                "control", "foo", "qa_override")))));
     }
-
 }

--- a/alchemy-api/src/test/java/io/rtr/alchemy/dto/models/AllocationDtoTest.java
+++ b/alchemy-api/src/test/java/io/rtr/alchemy/dto/models/AllocationDtoTest.java
@@ -7,10 +7,6 @@ import org.junit.Test;
 public class AllocationDtoTest {
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(AllocationDto.class)
-            .suppress(Warning.STRICT_INHERITANCE)
-            .verify();
+        EqualsVerifier.forClass(AllocationDto.class).suppress(Warning.STRICT_INHERITANCE).verify();
     }
-
 }

--- a/alchemy-api/src/test/java/io/rtr/alchemy/dto/models/ExperimentDtoTest.java
+++ b/alchemy-api/src/test/java/io/rtr/alchemy/dto/models/ExperimentDtoTest.java
@@ -7,9 +7,6 @@ import org.junit.Test;
 public class ExperimentDtoTest {
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(ExperimentDto.class)
-            .suppress(Warning.STRICT_INHERITANCE)
-            .verify();
+        EqualsVerifier.forClass(ExperimentDto.class).suppress(Warning.STRICT_INHERITANCE).verify();
     }
 }

--- a/alchemy-api/src/test/java/io/rtr/alchemy/dto/models/TreatmentDtoTest.java
+++ b/alchemy-api/src/test/java/io/rtr/alchemy/dto/models/TreatmentDtoTest.java
@@ -7,9 +7,6 @@ import org.junit.Test;
 public class TreatmentDtoTest {
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(TreatmentDto.class)
-            .suppress(Warning.STRICT_INHERITANCE)
-            .verify();
+        EqualsVerifier.forClass(TreatmentDto.class).suppress(Warning.STRICT_INHERITANCE).verify();
     }
 }

--- a/alchemy-api/src/test/java/io/rtr/alchemy/dto/models/TreatmentOverrideDtoTest.java
+++ b/alchemy-api/src/test/java/io/rtr/alchemy/dto/models/TreatmentOverrideDtoTest.java
@@ -7,9 +7,8 @@ import org.junit.Test;
 public class TreatmentOverrideDtoTest {
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(TreatmentOverrideDto.class)
-            .suppress(Warning.STRICT_INHERITANCE)
-            .verify();
+        EqualsVerifier.forClass(TreatmentOverrideDto.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
     }
 }

--- a/alchemy-client/pom.xml
+++ b/alchemy-client/pom.xml
@@ -44,7 +44,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
+        <version>${maven-shade-plugin.version}</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <filters>

--- a/alchemy-client/src/main/java/io/rtr/alchemy/client/AlchemyClient.java
+++ b/alchemy-client/src/main/java/io/rtr/alchemy/client/AlchemyClient.java
@@ -39,13 +39,12 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-/**
- * A Dropwizard client for talking to an instance Alchemy service
- */
+/** A Dropwizard client for talking to an instance Alchemy service */
 public class AlchemyClient {
     private static final String CLIENT_NAME = "alchemy-client";
     private static final Map<String, ?> EMPTY_PATH_PARAMS = Maps.newHashMap();
-    private static final ListMultimap<String, Object> EMPTY_QUERY_PARAMS = ArrayListMultimap.create();
+    private static final ListMultimap<String, Object> EMPTY_QUERY_PARAMS =
+            ArrayListMultimap.create();
     private static final ClassTypeMapper CLASS_TYPE_MAPPER = new ClassTypeMapper();
     private final MetricRegistry metricRegistry = new MetricRegistry();
     private final JerseyClientBuilder clientBuilder = new JerseyClientBuilder(metricRegistry);
@@ -61,114 +60,114 @@ public class AlchemyClient {
     private static final String ENDPOINT_EXPERIMENT = "/experiments/{experimentName}";
     private static final String ENDPOINT_ALLOCATIONS = "/experiments/{experimentName}/allocations";
     private static final String ENDPOINT_TREATMENTS = "/experiments/{experimentName}/treatments";
-    private static final String ENDPOINT_TREATMENT = "/experiments/{experimentName}/treatments/{treatmentName}";
+    private static final String ENDPOINT_TREATMENT =
+            "/experiments/{experimentName}/treatments/{treatmentName}";
     private static final String ENDPOINT_OVERRIDES = "/experiments/{experimentName}/overrides";
-    private static final String ENDPOINT_OVERRIDE = "/experiments/{experimentName}/overrides/{overrideName}";
-    private static final String ENDPOINT_ACTIVE_TREATMENT = "/active/experiments/{experimentName}/treatment";
+    private static final String ENDPOINT_OVERRIDE =
+            "/experiments/{experimentName}/overrides/{overrideName}";
+    private static final String ENDPOINT_ACTIVE_TREATMENT =
+            "/active/experiments/{experimentName}/treatment";
     private static final String ENDPOINT_ACTIVE_TREATMENTS = "/active/treatments";
     private static final String ENDPOINT_METADATA_IDENTITY_TYPES = "/metadata/identityTypes";
-    private static final String ENDPOINT_METADATA_IDENTITY_TYPE_SCHEMA = "/metadata/identityTypes/{identityType}/schema";
-    private static final String ENDPOINT_METADATA_IDENTITY_TYPE_ATTRIBUTES = "/metadata/identityTypes/{identityType}/attributes";
+    private static final String ENDPOINT_METADATA_IDENTITY_TYPE_SCHEMA =
+            "/metadata/identityTypes/{identityType}/schema";
+    private static final String ENDPOINT_METADATA_IDENTITY_TYPE_ATTRIBUTES =
+            "/metadata/identityTypes/{identityType}/attributes";
 
-    private final Function<GetExperimentsRequest, List<ExperimentDto>> GET_EXPERIMENTS_REQUEST_BUILDER =
-        new Function<GetExperimentsRequest, List<ExperimentDto>>() {
-            @Nullable
-            @Override
-            public List<ExperimentDto> apply(@Nullable GetExperimentsRequest request) {
-                if (request == null) {
-                    return null;
-                }
+    private final Function<GetExperimentsRequest, List<ExperimentDto>>
+            GET_EXPERIMENTS_REQUEST_BUILDER =
+                    new Function<GetExperimentsRequest, List<ExperimentDto>>() {
+                        @Nullable
+                        @Override
+                        public List<ExperimentDto> apply(@Nullable GetExperimentsRequest request) {
+                            if (request == null) {
+                                return null;
+                            }
 
-                final ListMultimap<String, Object> queryParams = ArrayListMultimap.create();
+                            final ListMultimap<String, Object> queryParams =
+                                    ArrayListMultimap.create();
 
-                if (request.getFilter() != null) {
-                    queryParams.put("filter", request.getFilter());
-                }
+                            if (request.getFilter() != null) {
+                                queryParams.put("filter", request.getFilter());
+                            }
 
-                if (request.getOffset() != null) {
-                    queryParams.put("offset", request.getOffset());
-                }
+                            if (request.getOffset() != null) {
+                                queryParams.put("offset", request.getOffset());
+                            }
 
-                if (request.getLimit() != null) {
-                    queryParams.put("limit", request.getLimit());
-                }
+                            if (request.getLimit() != null) {
+                                queryParams.put("limit", request.getLimit());
+                            }
 
-                if (request.getSort() != null) {
-                    queryParams.put("sort", request.getSort());
-                }
+                            if (request.getSort() != null) {
+                                queryParams.put("sort", request.getSort());
+                            }
 
-                final Invocation.Builder builder = resource(ENDPOINT_EXPERIMENTS, queryParams);
-                return builder.get(list(ExperimentDto.class));
-            }
-        };
+                            final Invocation.Builder builder =
+                                    resource(ENDPOINT_EXPERIMENTS, queryParams);
+                            return builder.get(list(ExperimentDto.class));
+                        }
+                    };
 
-    /**
-     * Constructs a client with the given dropwizard environment
-     */
+    /** Constructs a client with the given dropwizard environment */
     public AlchemyClient(AlchemyClientConfiguration configuration, Environment environment) {
-        this.client = clientBuilder
-            .using(environment)
-            .using(configuration)
-            .build(CLIENT_NAME);
+        this.client = clientBuilder.using(environment).using(configuration).build(CLIENT_NAME);
         this.configuration = configuration;
         configureObjectMapper(configuration, environment.getObjectMapper());
     }
 
-    /**
-     * Constructs a client with the given executor service and object mapper
-     */
-    public AlchemyClient(AlchemyClientConfiguration configuration,
-                         ExecutorService executorService,
-                         ObjectMapper objectMapper) {
-        this.client = clientBuilder
-            .using(executorService, objectMapper)
-            .using(configuration)
-            .build(CLIENT_NAME);
+    /** Constructs a client with the given executor service and object mapper */
+    public AlchemyClient(
+            AlchemyClientConfiguration configuration,
+            ExecutorService executorService,
+            ObjectMapper objectMapper) {
+        this.client =
+                clientBuilder
+                        .using(executorService, objectMapper)
+                        .using(configuration)
+                        .build(CLIENT_NAME);
         this.configuration = configuration;
         configureObjectMapper(configuration, objectMapper);
     }
 
-    /**
-     * Constructs a client with the given executor service
-     */
-    public AlchemyClient(AlchemyClientConfiguration configuration,
-                         ExecutorService executorService) {
+    /** Constructs a client with the given executor service */
+    public AlchemyClient(
+            AlchemyClientConfiguration configuration, ExecutorService executorService) {
         final ObjectMapper mapper = Jackson.newObjectMapper();
-        this.client = clientBuilder
-            .using(executorService, mapper)
-            .using(configuration)
-            .build(CLIENT_NAME);
+        this.client =
+                clientBuilder
+                        .using(executorService, mapper)
+                        .using(configuration)
+                        .build(CLIENT_NAME);
         this.configuration = configuration;
         configureObjectMapper(configuration, mapper);
     }
 
-    /**
-     * Constructs a client with reasonable multi-threading defaults
-     */
+    /** Constructs a client with reasonable multi-threading defaults */
     public AlchemyClient(AlchemyClientConfiguration configuration) {
         final ObjectMapper mapper = Jackson.newObjectMapper();
-        final ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
-        this.client = clientBuilder
-            .using(executorService, mapper)
-            .using(configuration)
-            .build(CLIENT_NAME);
+        final ExecutorService executorService =
+                Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        this.client =
+                clientBuilder
+                        .using(executorService, mapper)
+                        .using(configuration)
+                        .build(CLIENT_NAME);
         this.configuration = configuration;
         configureObjectMapper(configuration, mapper);
     }
 
-    private static void configureObjectMapper(AlchemyClientConfiguration configuration, ObjectMapper mapper) {
+    private static void configureObjectMapper(
+            AlchemyClientConfiguration configuration, ObjectMapper mapper) {
         mapper.registerSubtypes(
-            configuration
-                .getIdentityTypes()
-                .toArray(new Class<?>[configuration.getIdentityTypes().size()])
-        );
+                configuration
+                        .getIdentityTypes()
+                        .toArray(new Class<?>[configuration.getIdentityTypes().size()]));
     }
 
-    private URI assembleRequestURI(Map<String, ?> pathParams, ListMultimap<String, Object> queryParams, String path) {
-        final UriBuilder builder =
-            UriBuilder
-                .fromUri(configuration.getService())
-                .path(path);
+    private URI assembleRequestURI(
+            Map<String, ?> pathParams, ListMultimap<String, Object> queryParams, String path) {
+        final UriBuilder builder = UriBuilder.fromUri(configuration.getService()).path(path);
 
         for (String queryParam : queryParams.keySet()) {
             final List<Object> values = queryParams.get(queryParam);
@@ -182,25 +181,20 @@ public class AlchemyClient {
     }
 
     protected Invocation.Builder resource(String path, Map<String, ?> pathParams) {
-        return
-            client
-                .target(assembleRequestURI(pathParams, EMPTY_QUERY_PARAMS, path))
+        return client.target(assembleRequestURI(pathParams, EMPTY_QUERY_PARAMS, path))
                 .request()
                 .accept(MediaType.APPLICATION_JSON_TYPE);
     }
 
     protected Invocation.Builder resource(String path, ListMultimap<String, Object> queryParams) {
-        return
-            client
-                .target(assembleRequestURI(EMPTY_PATH_PARAMS, queryParams, path))
+        return client.target(assembleRequestURI(EMPTY_PATH_PARAMS, queryParams, path))
                 .request()
                 .accept(MediaType.APPLICATION_JSON_TYPE);
     }
 
-    protected Invocation.Builder resource(String path, Map<String, ?> pathParams, ListMultimap<String, Object> queryParams) {
-        return
-            client
-                .target(assembleRequestURI(pathParams, queryParams, path))
+    protected Invocation.Builder resource(
+            String path, Map<String, ?> pathParams, ListMultimap<String, Object> queryParams) {
+        return client.target(assembleRequestURI(pathParams, queryParams, path))
                 .request()
                 .accept(MediaType.APPLICATION_JSON_TYPE);
     }
@@ -210,18 +204,15 @@ public class AlchemyClient {
     }
 
     protected static <K, V> GenericType<Map<K, V>> map(Class<K> keyType, Class<V> valueType) {
-        return new GenericType<>(new ParameterizedTypeImpl(Map.class, keyType, valueType) {
-        });
+        return new GenericType<>(new ParameterizedTypeImpl(Map.class, keyType, valueType) {});
     }
 
     protected static <T> GenericType<List<T>> list(Class<T> elementType) {
-        return new GenericType<>(new ParameterizedTypeImpl(List.class, elementType) {
-        });
+        return new GenericType<>(new ParameterizedTypeImpl(List.class, elementType) {});
     }
 
     protected static <T> GenericType<Set<T>> set(Class<T> elementType) {
-        return new GenericType<>(new ParameterizedTypeImpl(Set.class, elementType) {
-        });
+        return new GenericType<>(new ParameterizedTypeImpl(Set.class, elementType) {});
     }
 
     public List<ExperimentDto> getExperiments() {
@@ -233,56 +224,43 @@ public class AlchemyClient {
     }
 
     public ExperimentDto getExperiment(String experimentName) {
-        return resource(
-            ENDPOINT_EXPERIMENT,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).get(ExperimentDto.class);
+        return resource(ENDPOINT_EXPERIMENT, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .get(ExperimentDto.class);
     }
 
     public List<AllocationDto> getAllocations(String experimentName) {
-        return
-            resource(
-                ENDPOINT_ALLOCATIONS,
-                ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName)
-            ).get(list(AllocationDto.class));
+        return resource(
+                        ENDPOINT_ALLOCATIONS,
+                        ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .get(list(AllocationDto.class));
     }
 
     public List<TreatmentDto> getTreatments(String experimentName) {
-        return resource(
-            ENDPOINT_TREATMENTS,
-            ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName)
-        ).get(list(TreatmentDto.class));
+        return resource(ENDPOINT_TREATMENTS, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .get(list(TreatmentDto.class));
     }
 
     public TreatmentDto getTreatment(String experimentName, String treatmentName) {
         return resource(
-            ENDPOINT_TREATMENT,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName,
-                PARAM_TREATMENT_NAME, treatmentName
-            )
-        ).get(TreatmentDto.class);
+                        ENDPOINT_TREATMENT,
+                        ImmutableMap.of(
+                                PARAM_EXPERIMENT_NAME, experimentName,
+                                PARAM_TREATMENT_NAME, treatmentName))
+                .get(TreatmentDto.class);
     }
 
     public List<TreatmentOverrideDto> getOverrides(String experimentName) {
-        return resource(
-            ENDPOINT_OVERRIDES,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).get(list(TreatmentOverrideDto.class));
+        return resource(ENDPOINT_OVERRIDES, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .get(list(TreatmentOverrideDto.class));
     }
 
     public TreatmentOverrideDto getOverride(String experimentName, String overrideName) {
         return resource(
-            ENDPOINT_OVERRIDE,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName,
-                PARAM_OVERRIDE_NAME, overrideName
-            )
-        ).get(TreatmentOverrideDto.class);
+                        ENDPOINT_OVERRIDE,
+                        ImmutableMap.of(
+                                PARAM_EXPERIMENT_NAME, experimentName,
+                                PARAM_OVERRIDE_NAME, overrideName))
+                .get(TreatmentOverrideDto.class);
     }
 
     public CreateExperimentRequestBuilder createExperiment(String experimentName) {
@@ -290,156 +268,118 @@ public class AlchemyClient {
     }
 
     public void addTreatment(String experimentName, String treatmentName, String description) {
-        resource(
-            ENDPOINT_TREATMENTS,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).put(Entity.json(new TreatmentDto(treatmentName, description)));
+        resource(ENDPOINT_TREATMENTS, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .put(Entity.json(new TreatmentDto(treatmentName, description)));
     }
 
     public void addTreatment(String experimentName, String treatmentName) {
         addTreatment(experimentName, treatmentName, null);
     }
 
-    public void addOverride(String experimentName,
-                            String overrideName,
-                            String treatmentName,
-                            String filter) {
-        resource(
-            ENDPOINT_OVERRIDES,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).put(Entity.entity(
-            new TreatmentOverrideRequest(treatmentName, filter, overrideName),
-            MediaType.APPLICATION_JSON_TYPE)
-        );
+    public void addOverride(
+            String experimentName, String overrideName, String treatmentName, String filter) {
+        resource(ENDPOINT_OVERRIDES, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .put(
+                        Entity.entity(
+                                new TreatmentOverrideRequest(treatmentName, filter, overrideName),
+                                MediaType.APPLICATION_JSON_TYPE));
     }
 
     public UpdateExperimentRequestBuilder updateExperiment(String experimentName) {
         return new UpdateExperimentRequestBuilder(
-            resource(
-                ENDPOINT_EXPERIMENT,
-                ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName)
-            )
-        );
+                resource(
+                        ENDPOINT_EXPERIMENT,
+                        ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName)));
     }
 
     public UpdateAllocationsRequestBuilder updateAllocations(String experimentName) {
         return new UpdateAllocationsRequestBuilder(
-            resource(
-                ENDPOINT_ALLOCATIONS,
-                ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName)
-            )
-        );
+                resource(
+                        ENDPOINT_ALLOCATIONS,
+                        ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName)));
     }
 
     public TreatmentDto getActiveTreatment(String experimentName, IdentityDto identity) {
         return resource(
-            ENDPOINT_ACTIVE_TREATMENT,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).post(
-            Entity.entity(identity, MediaType.APPLICATION_JSON_TYPE),
-            TreatmentDto.class);
+                        ENDPOINT_ACTIVE_TREATMENT,
+                        ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .post(Entity.entity(identity, MediaType.APPLICATION_JSON_TYPE), TreatmentDto.class);
     }
 
     public Map<String, TreatmentDto> getActiveTreatments(IdentityDto identity) {
-        return
-            resource(ENDPOINT_ACTIVE_TREATMENTS)
+        return resource(ENDPOINT_ACTIVE_TREATMENTS)
                 .post(
-                    Entity.entity(identity, MediaType.APPLICATION_JSON_TYPE),
-                    map(String.class, TreatmentDto.class));
+                        Entity.entity(identity, MediaType.APPLICATION_JSON_TYPE),
+                        map(String.class, TreatmentDto.class));
     }
 
     public void deleteExperiment(String experimentName) {
-        resource(
-            ENDPOINT_EXPERIMENT,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).delete();
+        resource(ENDPOINT_EXPERIMENT, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .delete();
     }
 
     public void clearAllocations(String experimentName) {
-        resource(
-            ENDPOINT_ALLOCATIONS,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).delete();
+        resource(ENDPOINT_ALLOCATIONS, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .delete();
     }
 
     public void removeTreatment(String experimentName, String treatmentName) {
         resource(
-            ENDPOINT_TREATMENT,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName,
-                PARAM_TREATMENT_NAME, treatmentName
-            )
-        ).delete();
+                        ENDPOINT_TREATMENT,
+                        ImmutableMap.of(
+                                PARAM_EXPERIMENT_NAME, experimentName,
+                                PARAM_TREATMENT_NAME, treatmentName))
+                .delete();
     }
 
-    public UpdateTreatmentRequestBuilder updateTreatment(String experimentName, String treatmentName) {
+    public UpdateTreatmentRequestBuilder updateTreatment(
+            String experimentName, String treatmentName) {
         return new UpdateTreatmentRequestBuilder(
-            resource(
-                ENDPOINT_TREATMENT,
-                ImmutableMap.of(
-                    PARAM_EXPERIMENT_NAME, experimentName,
-                    PARAM_TREATMENT_NAME, treatmentName
-                )
-            )
-        );
+                resource(
+                        ENDPOINT_TREATMENT,
+                        ImmutableMap.of(
+                                PARAM_EXPERIMENT_NAME, experimentName,
+                                PARAM_TREATMENT_NAME, treatmentName)));
     }
 
     public void clearTreatments(String experimentName) {
-        resource(
-            ENDPOINT_TREATMENTS,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).delete();
+        resource(ENDPOINT_TREATMENTS, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .delete();
     }
 
     public void clearOverrides(String experimentName) {
-        resource(
-            ENDPOINT_OVERRIDES,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName
-            )
-        ).delete();
+        resource(ENDPOINT_OVERRIDES, ImmutableMap.of(PARAM_EXPERIMENT_NAME, experimentName))
+                .delete();
     }
 
     public void removeOverride(String experimentName, String overrideName) {
         resource(
-            ENDPOINT_OVERRIDE,
-            ImmutableMap.of(
-                PARAM_EXPERIMENT_NAME, experimentName,
-                PARAM_OVERRIDE_NAME, overrideName
-            )
-        ).delete();
+                        ENDPOINT_OVERRIDE,
+                        ImmutableMap.of(
+                                PARAM_EXPERIMENT_NAME, experimentName,
+                                PARAM_OVERRIDE_NAME, overrideName))
+                .delete();
     }
 
     public Map<String, Class<? extends IdentityDto>> getIdentityTypes() {
-        final Map<String, Class> map = resource(ENDPOINT_METADATA_IDENTITY_TYPES).get(map(String.class, Class.class));
+        final Map<String, Class> map =
+                resource(ENDPOINT_METADATA_IDENTITY_TYPES).get(map(String.class, Class.class));
 
         return Maps.transformValues(map, CLASS_TYPE_MAPPER);
     }
 
     public JsonSchema getIdentitySchema(String identityType) {
         return resource(
-            ENDPOINT_METADATA_IDENTITY_TYPE_SCHEMA,
-            ImmutableMap.of(PARAM_IDENTITY_TYPE_NAME, identityType)
-        ).get(JsonSchema.class);
+                        ENDPOINT_METADATA_IDENTITY_TYPE_SCHEMA,
+                        ImmutableMap.of(PARAM_IDENTITY_TYPE_NAME, identityType))
+                .get(JsonSchema.class);
     }
 
     public Set<String> getIdentityAttributes(String identityType) {
         return resource(
-            ENDPOINT_METADATA_IDENTITY_TYPE_ATTRIBUTES,
-            ImmutableMap.of(PARAM_IDENTITY_TYPE_NAME, identityType)
-        ).get(set(String.class));
+                        ENDPOINT_METADATA_IDENTITY_TYPE_ATTRIBUTES,
+                        ImmutableMap.of(PARAM_IDENTITY_TYPE_NAME, identityType))
+                .get(set(String.class));
     }
 
     private static class ClassTypeMapper implements Function<Class, Class<? extends IdentityDto>> {

--- a/alchemy-client/src/main/java/io/rtr/alchemy/client/AlchemyClientConfiguration.java
+++ b/alchemy-client/src/main/java/io/rtr/alchemy/client/AlchemyClientConfiguration.java
@@ -9,19 +9,16 @@ import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.util.Set;
 
-/**
- * The client configuration
- */
+/** The client configuration */
 public class AlchemyClientConfiguration extends JerseyClientConfiguration {
-    @NotNull
-    private final URI service;
+    @NotNull private final URI service;
 
-    @NotNull
-    private final Set<Class<? extends IdentityDto>> identityTypes;
+    @NotNull private final Set<Class<? extends IdentityDto>> identityTypes;
 
     @JsonCreator
-    public AlchemyClientConfiguration(@JsonProperty("service") URI service,
-                                      @JsonProperty("identityTypes") Set<Class<? extends IdentityDto>> identityTypes) {
+    public AlchemyClientConfiguration(
+            @JsonProperty("service") URI service,
+            @JsonProperty("identityTypes") Set<Class<? extends IdentityDto>> identityTypes) {
         this.service = service;
         this.identityTypes = identityTypes;
     }

--- a/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/CreateExperimentRequestBuilder.java
+++ b/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/CreateExperimentRequestBuilder.java
@@ -84,23 +84,25 @@ public class CreateExperimentRequestBuilder {
         return this;
     }
 
-    public CreateExperimentRequestBuilder addOverride(String name, String treatmentName, String filter) {
+    public CreateExperimentRequestBuilder addOverride(
+            String name, String treatmentName, String filter) {
         overrides.add(new TreatmentOverrideRequest(treatmentName, filter, name));
         return this;
     }
 
     public void apply() {
-        builder.put(Entity.entity(
-            new CreateExperimentRequest(
-                name,
-                seed,
-                description,
-                filter,
-                hashAttributes,
-                isActive,
-                treatments,
-                allocations,
-                overrides),
-            APPLICATION_JSON));
+        builder.put(
+                Entity.entity(
+                        new CreateExperimentRequest(
+                                name,
+                                seed,
+                                description,
+                                filter,
+                                hashAttributes,
+                                isActive,
+                                treatments,
+                                allocations,
+                                overrides),
+                        APPLICATION_JSON));
     }
 }

--- a/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/GetExperimentsRequestBuilder.java
+++ b/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/GetExperimentsRequestBuilder.java
@@ -13,7 +13,8 @@ public class GetExperimentsRequestBuilder {
     private Integer limit;
     private String sort;
 
-    public GetExperimentsRequestBuilder(Function<GetExperimentsRequest, List<ExperimentDto>> builder) {
+    public GetExperimentsRequestBuilder(
+            Function<GetExperimentsRequest, List<ExperimentDto>> builder) {
         this.builder = builder;
     }
 
@@ -38,13 +39,6 @@ public class GetExperimentsRequestBuilder {
     }
 
     public List<ExperimentDto> apply() {
-        return builder.apply(
-            new GetExperimentsRequest(
-                filter,
-                offset,
-                limit,
-                sort
-            )
-        );
+        return builder.apply(new GetExperimentsRequest(filter, offset, limit, sort));
     }
 }

--- a/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/UpdateAllocationsRequestBuilder.java
+++ b/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/UpdateAllocationsRequestBuilder.java
@@ -17,7 +17,7 @@ public class UpdateAllocationsRequestBuilder {
     }
 
     public UpdateAllocationsRequestBuilder allocate(String treatmentName, int size) {
-        allocations.add(new AllocationRequest.Allocate(treatmentName,size));
+        allocations.add(new AllocationRequest.Allocate(treatmentName, size));
 
         return this;
     }
@@ -27,7 +27,8 @@ public class UpdateAllocationsRequestBuilder {
         return this;
     }
 
-    public UpdateAllocationsRequestBuilder reallocate(final String treatmentName, final String target, final int size) {
+    public UpdateAllocationsRequestBuilder reallocate(
+            final String treatmentName, final String target, final int size) {
         allocations.add(new AllocationRequest.Reallocate(treatmentName, size, target));
         return this;
     }

--- a/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/UpdateExperimentRequestBuilder.java
+++ b/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/UpdateExperimentRequestBuilder.java
@@ -49,8 +49,9 @@ public class UpdateExperimentRequestBuilder {
         return this;
     }
 
-    public UpdateExperimentRequestBuilder setHashAttributes(String ... hashAttributes) {
-        this.hashAttributes = Optional.ofNullable(Sets.newLinkedHashSet(Lists.newArrayList(hashAttributes)));
+    public UpdateExperimentRequestBuilder setHashAttributes(String... hashAttributes) {
+        this.hashAttributes =
+                Optional.ofNullable(Sets.newLinkedHashSet(Lists.newArrayList(hashAttributes)));
         return this;
     }
 
@@ -80,18 +81,17 @@ public class UpdateExperimentRequestBuilder {
     }
 
     public void apply() {
-        builder.post(Entity.entity(
-            new UpdateExperimentRequest(
-                seed,
-                description,
-                filter,
-                hashAttributes,
-                active,
-                treatments,
-                allocations,
-                overrides
-            ), MediaType.APPLICATION_JSON_TYPE)
-        );
+        builder.post(
+                Entity.entity(
+                        new UpdateExperimentRequest(
+                                seed,
+                                description,
+                                filter,
+                                hashAttributes,
+                                active,
+                                treatments,
+                                allocations,
+                                overrides),
+                        MediaType.APPLICATION_JSON_TYPE));
     }
-
 }

--- a/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/UpdateTreatmentRequestBuilder.java
+++ b/alchemy-client/src/main/java/io/rtr/alchemy/client/builder/UpdateTreatmentRequestBuilder.java
@@ -21,6 +21,8 @@ public class UpdateTreatmentRequestBuilder {
     }
 
     public void apply() {
-        builder.post(Entity.entity(new UpdateTreatmentRequest(description), MediaType.APPLICATION_JSON_TYPE));
+        builder.post(
+                Entity.entity(
+                        new UpdateTreatmentRequest(description), MediaType.APPLICATION_JSON_TYPE));
     }
 }

--- a/alchemy-client/src/test/java/io/rtr/alchemy/client/AlchemyClientTest.java
+++ b/alchemy-client/src/test/java/io/rtr/alchemy/client/AlchemyClientTest.java
@@ -37,9 +37,11 @@ import static org.junit.Assert.fail;
 
 public class AlchemyClientTest {
     private static final ArrayList<String> experimentsToBeDeleted = new ArrayList<>();
+
     private static String getResourcePath(String resourceName) {
         try {
-            final URL resourceUrl = AlchemyClientTest.class.getClassLoader().getResource(resourceName);
+            final URL resourceUrl =
+                    AlchemyClientTest.class.getClassLoader().getResource(resourceName);
             assertNotNull(resourceUrl);
             return (new File(resourceUrl.toURI())).getAbsolutePath();
         } catch (final Exception e) {
@@ -52,8 +54,8 @@ public class AlchemyClientTest {
     }
 
     @ClassRule
-    public final static DropwizardAppRule<AlchemyServiceConfigurationImpl> RULE =
-        new DropwizardAppRule<>(WrapperService.class, getResourcePath("test-server.yaml"));
+    public static final DropwizardAppRule<AlchemyServiceConfigurationImpl> RULE =
+            new DropwizardAppRule<>(WrapperService.class, getResourcePath("test-server.yaml"));
 
     private AlchemyClient client;
 
@@ -62,10 +64,11 @@ public class AlchemyClientTest {
         final Set<Class<? extends IdentityDto>> identityTypes = Sets.newHashSet();
         identityTypes.add(UserDto.class);
 
-        client = new AlchemyClient(new AlchemyClientConfiguration(
-            new URI(String.format("http://localhost:%d", RULE.getLocalPort())),
-            identityTypes
-        ));
+        client =
+                new AlchemyClient(
+                        new AlchemyClientConfiguration(
+                                new URI(String.format("http://localhost:%d", RULE.getLocalPort())),
+                                identityTypes));
     }
 
     @After
@@ -79,11 +82,7 @@ public class AlchemyClientTest {
 
     @Test
     public void testCreateExperiment() {
-        client
-            .createExperiment("exp")
-            .setDescription("this is an experiment")
-            .activate()
-            .apply();
+        client.createExperiment("exp").setDescription("this is an experiment").activate().apply();
         experimentsToBeDeleted.add("exp");
 
         final ExperimentDto experiment = client.getExperiment("exp");
@@ -94,11 +93,7 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetExperiments() {
-        client
-            .createExperiment("exp")
-            .setDescription("this is an experiment")
-            .activate()
-            .apply();
+        client.createExperiment("exp").setDescription("this is an experiment").activate().apply();
         experimentsToBeDeleted.add("exp");
 
         final List<ExperimentDto> experiments = client.getExperiments();
@@ -112,49 +107,42 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetExperimentsFiltered() {
-        client
-            .createExperiment("exp")
-            .setDescription("this is an experiment")
-            .activate()
-            .apply();
+        client.createExperiment("exp").setDescription("this is an experiment").activate().apply();
         experimentsToBeDeleted.add("exp");
 
-        client
-            .createExperiment("another_exp")
-            .setDescription("another experiment")
-            .activate()
-            .apply();
+        client.createExperiment("another_exp")
+                .setDescription("another experiment")
+                .activate()
+                .apply();
         experimentsToBeDeleted.add("another_exp");
 
-        final List<ExperimentDto> experiments1 = client.getExperimentsFiltered().sort("name").limit(1).apply();
+        final List<ExperimentDto> experiments1 =
+                client.getExperimentsFiltered().sort("name").limit(1).apply();
         assertEquals(1, experiments1.size());
         assertEquals("another_exp", experiments1.get(0).getName());
 
-        final List<ExperimentDto> experiments2 = client.getExperimentsFiltered().sort("name").offset(1).apply();
+        final List<ExperimentDto> experiments2 =
+                client.getExperimentsFiltered().sort("name").offset(1).apply();
         assertEquals(1, experiments2.size());
         assertEquals("exp", experiments2.get(0).getName());
 
-        final List<ExperimentDto> experiments3 = client.getExperimentsFiltered().sort("-name").offset(1).apply();
+        final List<ExperimentDto> experiments3 =
+                client.getExperimentsFiltered().sort("-name").offset(1).apply();
         assertEquals(1, experiments3.size());
         assertEquals("another_exp", experiments3.get(0).getName());
 
-        final List<ExperimentDto> experiments4 = client.getExperimentsFiltered().filter("another").apply();
+        final List<ExperimentDto> experiments4 =
+                client.getExperimentsFiltered().filter("another").apply();
         assertEquals(1, experiments4.size());
         assertEquals("another_exp", experiments4.get(0).getName());
     }
 
     @Test
     public void testUpdateExperiment() {
-        client
-            .createExperiment("exp")
-            .activate()
-            .apply();
+        client.createExperiment("exp").activate().apply();
         experimentsToBeDeleted.add("exp");
 
-        client
-            .updateExperiment("exp")
-            .setDescription("this is an experiment")
-            .apply();
+        client.updateExperiment("exp").setDescription("this is an experiment").apply();
 
         final ExperimentDto experiment = client.getExperiment("exp");
         assertEquals("exp", experiment.getName());
@@ -164,9 +152,7 @@ public class AlchemyClientTest {
 
     @Test
     public void testDeleteExperiment() {
-        client
-            .createExperiment("exp")
-            .apply();
+        client.createExperiment("exp").apply();
 
         assertNotNull(client.getExperiment("exp"));
         client.deleteExperiment("exp");
@@ -181,9 +167,7 @@ public class AlchemyClientTest {
 
     @Test
     public void testAddTreatment() {
-        client
-            .createExperiment("exp")
-            .apply();
+        client.createExperiment("exp").apply();
         experimentsToBeDeleted.add("exp");
 
         client.addTreatment("exp", "control", "the control");
@@ -201,29 +185,20 @@ public class AlchemyClientTest {
 
     @Test
     public void testUpdateTreatment() {
-        client
-            .createExperiment("exp")
-            .apply();
+        client.createExperiment("exp").apply();
         experimentsToBeDeleted.add("exp");
 
         client.addTreatment("exp", "control", "the control");
-        client
-            .updateTreatment("exp", "control")
-            .setDescription("new description")
-            .apply();
+        client.updateTreatment("exp", "control").setDescription("new description").apply();
 
         final TreatmentDto treatment = client.getTreatment("exp", "control");
         assertEquals("control", treatment.getName());
         assertEquals("new description", treatment.getDescription());
-
     }
 
     @Test
     public void testRemoveTreatment() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .apply();
+        client.createExperiment("exp").addTreatment("control").apply();
         experimentsToBeDeleted.add("exp");
 
         client.removeTreatment("exp", "control");
@@ -233,10 +208,7 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetTreatments() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control", "the control")
-            .apply();
+        client.createExperiment("exp").addTreatment("control", "the control").apply();
         experimentsToBeDeleted.add("exp");
 
         final List<TreatmentDto> treatments = client.getTreatments("exp");
@@ -250,10 +222,7 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetTreatment() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control", "the control")
-            .apply();
+        client.createExperiment("exp").addTreatment("control", "the control").apply();
         experimentsToBeDeleted.add("exp");
 
         final TreatmentDto treatment = client.getTreatment("exp", "control");
@@ -263,10 +232,7 @@ public class AlchemyClientTest {
 
     @Test
     public void testClearTreatments() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .apply();
+        client.createExperiment("exp").addTreatment("control").apply();
         experimentsToBeDeleted.add("exp");
 
         client.clearTreatments("exp");
@@ -275,11 +241,7 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetAllocations() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .allocate("control", 50)
-            .apply();
+        client.createExperiment("exp").addTreatment("control").allocate("control", 50).apply();
         experimentsToBeDeleted.add("exp");
 
         final List<AllocationDto> allocations = client.getAllocations("exp");
@@ -293,27 +255,17 @@ public class AlchemyClientTest {
 
     @Test
     public void testUpdateAllocations() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .apply();
+        client.createExperiment("exp").addTreatment("control").apply();
         experimentsToBeDeleted.add("exp");
 
-        client
-            .updateAllocations("exp")
-            .allocate("control", 100)
-            .apply();
+        client.updateAllocations("exp").allocate("control", 100).apply();
 
         assertEquals(1, client.getAllocations("exp").size());
     }
 
     @Test
     public void testClearAllocations() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .allocate("control", 10)
-            .apply();
+        client.createExperiment("exp").addTreatment("control").allocate("control", 10).apply();
         experimentsToBeDeleted.add("exp");
 
         client.clearAllocations("exp");
@@ -323,11 +275,10 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetOverrides() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .addOverride("override", "control", "identified")
-            .apply();
+        client.createExperiment("exp")
+                .addTreatment("control")
+                .addOverride("override", "control", "identified")
+                .apply();
         experimentsToBeDeleted.add("exp");
 
         final List<TreatmentOverrideDto> overrides = client.getOverrides("exp");
@@ -341,11 +292,10 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetOverride() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .addOverride("override", "control", "identified")
-            .apply();
+        client.createExperiment("exp")
+                .addTreatment("control")
+                .addOverride("override", "control", "identified")
+                .apply();
         experimentsToBeDeleted.add("exp");
 
         final TreatmentOverrideDto override = client.getOverride("exp", "override");
@@ -355,11 +305,10 @@ public class AlchemyClientTest {
 
     @Test
     public void testRemoveOverride() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .addOverride("override", "control", "identified")
-            .apply();
+        client.createExperiment("exp")
+                .addTreatment("control")
+                .addOverride("override", "control", "identified")
+                .apply();
         experimentsToBeDeleted.add("exp");
 
         client.removeOverride("exp", "override");
@@ -369,11 +318,10 @@ public class AlchemyClientTest {
 
     @Test
     public void testClearOverrides() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .addOverride("override", "control", "identified")
-            .apply();
+        client.createExperiment("exp")
+                .addTreatment("control")
+                .addOverride("override", "control", "identified")
+                .apply();
         experimentsToBeDeleted.add("exp");
 
         client.clearOverrides("exp");
@@ -382,12 +330,11 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetActiveTreatment() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .addOverride("override", "control", "identified")
-            .activate()
-            .apply();
+        client.createExperiment("exp")
+                .addTreatment("control")
+                .addOverride("override", "control", "identified")
+                .activate()
+                .apply();
         experimentsToBeDeleted.add("exp");
 
         final TreatmentDto treatment = client.getActiveTreatment("exp", new UserDto("foo"));
@@ -396,12 +343,11 @@ public class AlchemyClientTest {
 
     @Test
     public void testGetActiveTreatments() {
-        client
-            .createExperiment("exp")
-            .addTreatment("control")
-            .addOverride("override", "control", "identified")
-            .activate()
-            .apply();
+        client.createExperiment("exp")
+                .addTreatment("control")
+                .addOverride("override", "control", "identified")
+                .activate()
+                .apply();
         experimentsToBeDeleted.add("exp");
 
         final Map<String, TreatmentDto> treatments = client.getActiveTreatments(new UserDto("foo"));
@@ -424,13 +370,7 @@ public class AlchemyClientTest {
     public void testGetIdentitySchema() {
         final JsonSchema map = client.getIdentitySchema("user");
         assertNotNull(map);
-        assertTrue(
-            map
-                .asObjectSchema()
-                .getProperties()
-                .get("name")
-                .isStringSchema()
-        );
+        assertTrue(map.asObjectSchema().getProperties().get("name").isStringSchema());
     }
 
     @Test

--- a/alchemy-client/src/test/java/io/rtr/alchemy/client/identities/User.java
+++ b/alchemy-client/src/test/java/io/rtr/alchemy/client/identities/User.java
@@ -20,17 +20,13 @@ public class User extends Identity {
 
     @Override
     public long computeHash(int seed, Set<String> hashAttributes, AttributesMap attributes) {
-        return
-            identity(seed)
-                .putString(name)
-                .hash();
+        return identity(seed).putString(name).hash();
     }
 
     @Override
     public AttributesMap computeAttributes() {
-        return
-            name == null ?
-            attributes().put("anonymous", true).build() :
-            attributes().put("identified", true).build();
+        return name == null
+                ? attributes().put("anonymous", true).build()
+                : attributes().put("identified", true).build();
     }
 }

--- a/alchemy-core/pom.xml
+++ b/alchemy-core/pom.xml
@@ -10,7 +10,8 @@
   <artifactId>alchemy-core</artifactId>
 
   <properties>
-    <antlr.version>4.13.1</antlr.version>
+    <!-- this is the last version with org.antlr.v4.runtime.misc.Nullable -->
+    <antlr.version>4.5</antlr.version>
   </properties>
 
   <dependencies>
@@ -55,6 +56,20 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.coveo</groupId>
+          <artifactId>fmt-maven-plugin</artifactId>
+          <version>${fmt-maven-plugin.version}</version>
+          <configuration combine.self="append">
+            <!-- doesn't play nice with the auto-generated files from antlr -->
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.antlr</groupId>

--- a/alchemy-core/pom.xml
+++ b/alchemy-core/pom.xml
@@ -9,6 +9,10 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>alchemy-core</artifactId>
 
+  <properties>
+    <antlr.version>4.13.1</antlr.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>joda-time</groupId>
@@ -41,7 +45,7 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
-      <version>4.2.2</version>
+      <version>${antlr.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>
@@ -55,7 +59,7 @@
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
-        <version>4.2.2</version>
+        <version>${antlr.version}</version>
         <configuration>
           <sourceDirectory>${basedir}/src/main/antlr4</sourceDirectory>
           <outputDirectory>src/main/java/io/rtr/alchemy/filtering</outputDirectory>

--- a/alchemy-core/src/main/java/io/rtr/alchemy/caching/BasicCacheStrategy.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/caching/BasicCacheStrategy.java
@@ -3,8 +3,8 @@ package io.rtr.alchemy.caching;
 import io.rtr.alchemy.models.Experiment;
 
 /**
- * Implements a basic cache strategy that will always update the cache any time an experiment is loaded, saved, or
- * deleted
+ * Implements a basic cache strategy that will always update the cache any time an experiment is
+ * loaded, saved, or deleted
  */
 public class BasicCacheStrategy implements CacheStrategy {
     private static void updateOrDelete(Experiment experiment, CachingContext context) {
@@ -31,10 +31,8 @@ public class BasicCacheStrategy implements CacheStrategy {
     }
 
     @Override
-    public void onCacheRead(String experimentName, CachingContext context) {
-    }
+    public void onCacheRead(String experimentName, CachingContext context) {}
 
     @Override
-    public void onCacheRead(CachingContext context) {
-    }
+    public void onCacheRead(CachingContext context) {}
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/caching/CacheStrategy.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/caching/CacheStrategy.java
@@ -2,32 +2,20 @@ package io.rtr.alchemy.caching;
 
 import io.rtr.alchemy.models.Experiment;
 
-/**
- * Defines the behavior for when to invalidate items in the cache
- */
+/** Defines the behavior for when to invalidate items in the cache */
 public interface CacheStrategy {
-    /**
-     * Fires when an experiment is loaded from the store
-     */
+    /** Fires when an experiment is loaded from the store */
     void onLoad(Experiment experiment, CachingContext context);
 
-    /**
-     * Fires when an experiment is saved to the store
-     */
+    /** Fires when an experiment is saved to the store */
     void onSave(Experiment experiment, CachingContext context);
 
-    /**
-     * Fires when an experiment is deleted from the store
-     */
+    /** Fires when an experiment is deleted from the store */
     void onDelete(String experimentName, CachingContext context);
 
-    /**
-     * Fires before an experiment is read from the cache
-     */
+    /** Fires before an experiment is read from the cache */
     void onCacheRead(String experimentName, CachingContext context);
 
-    /**
-     * Fires before all experiments are read from the cache
-     */
+    /** Fires before all experiments are read from the cache */
     void onCacheRead(CachingContext context);
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/caching/CacheStrategyIterable.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/caching/CacheStrategyIterable.java
@@ -5,16 +5,16 @@ import io.rtr.alchemy.models.Experiment;
 import java.util.Iterator;
 
 /**
- * Implements a wrapper around iterable of Experiment in order to trigger the cache strategy as results are retrieved
+ * Implements a wrapper around iterable of Experiment in order to trigger the cache strategy as
+ * results are retrieved
  */
 public class CacheStrategyIterable implements Iterable<Experiment> {
     private final Iterable<Experiment> iterable;
     private final CachingContext context;
     private final CacheStrategy strategy;
 
-    public CacheStrategyIterable(Iterable<Experiment> iterable,
-                                 CachingContext context,
-                                 CacheStrategy strategy) {
+    public CacheStrategyIterable(
+            Iterable<Experiment> iterable, CachingContext context, CacheStrategy strategy) {
         this.iterable = iterable;
         this.context = context;
         this.strategy = strategy;

--- a/alchemy-core/src/main/java/io/rtr/alchemy/caching/CachingContext.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/caching/CachingContext.java
@@ -11,8 +11,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * A context object that allows you to interact safely with the cache, preventing multiple calls to invalidate from
- * triggering redundant cache reloads and allowing the user the option to invalidate the cache asynchronously
+ * A context object that allows you to interact safely with the cache, preventing multiple calls to
+ * invalidate from triggering redundant cache reloads and allowing the user the option to invalidate
+ * the cache asynchronously
  */
 public class CachingContext implements Closeable {
     private final ExperimentsCache cache;
@@ -22,33 +23,33 @@ public class CachingContext implements Closeable {
     private final boolean ownsExecutorService;
     private final ConcurrentMap<String, AtomicBoolean> experimentLocks;
 
-    public CachingContext(ExperimentsCache cache,
-                          Experiment.BuilderFactory builderFactory,
-                          ExecutorService executorService) {
+    public CachingContext(
+            ExperimentsCache cache,
+            Experiment.BuilderFactory builderFactory,
+            ExecutorService executorService) {
         this.cache = cache;
         this.builderFactory = builderFactory;
-        this.executorService = executorService != null ? executorService : Executors.newSingleThreadExecutor();
+        this.executorService =
+                executorService != null ? executorService : Executors.newSingleThreadExecutor();
         this.ownsExecutorService = executorService == null;
         this.experimentLocks = Maps.newConcurrentMap();
         this.lock = new AtomicBoolean(false);
     }
 
-    public CachingContext(ExperimentsCache cache,
-                          Experiment.BuilderFactory builderFactory) {
+    public CachingContext(ExperimentsCache cache, Experiment.BuilderFactory builderFactory) {
         this(cache, builderFactory, null);
     }
 
-    /**
-     * Forces cache to reload all data from storage
-     */
+    /** Forces cache to reload all data from storage */
     public void invalidateAll(boolean async) {
         if (async) {
-            executorService.execute(new Runnable() {
-                @Override
-                public void run() {
-                    safeInvalidateAll(builderFactory);
-                }
-            });
+            executorService.execute(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            safeInvalidateAll(builderFactory);
+                        }
+                    });
         } else {
             safeInvalidateAll(builderFactory);
         }
@@ -72,17 +73,17 @@ public class CachingContext implements Closeable {
         return prevLock != null ? prevLock : newLock;
     }
 
-    /**
-     * Forces cache to reload a specific experiment from storage
-     */
+    /** Forces cache to reload a specific experiment from storage */
     public void invalidate(final String experimentName, boolean async) {
         if (async) {
-            executorService.execute(new Runnable() {
-                @Override
-                public void run() {
-                    safeInvalidate(experimentName, builderFactory.createBuilder(experimentName));
-                }
-            });
+            executorService.execute(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            safeInvalidate(
+                                    experimentName, builderFactory.createBuilder(experimentName));
+                        }
+                    });
         } else {
             safeInvalidate(experimentName, builderFactory.createBuilder(experimentName));
         }
@@ -103,30 +104,22 @@ public class CachingContext implements Closeable {
         }
     }
 
-    /**
-     * Updates the cache with a newly loaded experiment
-     */
+    /** Updates the cache with a newly loaded experiment */
     public void update(Experiment experiment) {
         cache.update(experiment);
     }
 
-    /**
-     * Updates the cache with a recently deleted experiment
-     */
+    /** Updates the cache with a recently deleted experiment */
     public void delete(String experimentName) {
         cache.delete(experimentName);
     }
 
-    /**
-     * Checks whether any experiments are stale
-     */
+    /** Checks whether any experiments are stale */
     public boolean checkIfAnyStale() {
         return cache.checkIfAnyStale();
     }
 
-    /**
-     * Checks whether a given experiment is stale
-     */
+    /** Checks whether a given experiment is stale */
     public boolean checkIfStale(String experimentName) {
         return cache.checkIfStale(experimentName);
     }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/caching/PeriodicStaleCheckingCacheStrategy.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/caching/PeriodicStaleCheckingCacheStrategy.java
@@ -6,9 +6,10 @@ import org.joda.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * This caching strategy will periodically check whether the data in the cache is stale, and if so, refresh it.
- * The periodic checking of staleness is driven by cache reads, so, any time the cache is read, if it's been a while
- * since the last refresh and the data is stale, the cache will be refreshed.
+ * This caching strategy will periodically check whether the data in the cache is stale, and if so,
+ * refresh it. The periodic checking of staleness is driven by cache reads, so, any time the cache
+ * is read, if it's been a while since the last refresh and the data is stale, the cache will be
+ * refreshed.
  */
 public class PeriodicStaleCheckingCacheStrategy extends BasicCacheStrategy {
     private final Duration period;

--- a/alchemy-core/src/main/java/io/rtr/alchemy/db/ExperimentsCache.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/db/ExperimentsCache.java
@@ -4,43 +4,32 @@ import io.rtr.alchemy.models.Experiment;
 import java.util.Map;
 
 /**
- * An interface for retrieving active experiments and treatments information, real-time.  Must be optimized and fast as this
- * will be called many times, ideally caching internally as needed.
+ * An interface for retrieving active experiments and treatments information, real-time. Must be
+ * optimized and fast as this will be called many times, ideally caching internally as needed.
  */
 public interface ExperimentsCache {
     /**
      * Return active experiments
+     *
      * @return all active experiments
      */
     Map<String, Experiment> getActiveExperiments();
 
-    /**
-     * Forces cache to reload all data from storage
-     */
+    /** Forces cache to reload all data from storage */
     void invalidateAll(Experiment.BuilderFactory factory);
 
-    /**
-     * Forces cache to reload a specific experiment from storage
-     */
+    /** Forces cache to reload a specific experiment from storage */
     void invalidate(String experimentName, Experiment.Builder builder);
 
-    /**
-     * Updates the cache with a newly loaded experiment
-     */
+    /** Updates the cache with a newly loaded experiment */
     void update(Experiment experiment);
 
-    /**
-     * Updates the cache with a recently deleted experiment
-     */
+    /** Updates the cache with a recently deleted experiment */
     void delete(String experimentName);
 
-    /**
-     * Checks whether any experiments are stale
-     */
+    /** Checks whether any experiments are stale */
     boolean checkIfAnyStale();
 
-    /**
-     * Checks whether a given experiment is stale
-     */
+    /** Checks whether a given experiment is stale */
     boolean checkIfStale(String experimentName);
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/db/ExperimentsStore.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/db/ExperimentsStore.java
@@ -3,18 +3,20 @@ package io.rtr.alchemy.db;
 import io.rtr.alchemy.models.Experiment;
 
 /**
- * An interface for defining basic CRUD operations around experiments, treatments and allocations.  These operations do
- * not need to be highly optimized or fast
+ * An interface for defining basic CRUD operations around experiments, treatments and allocations.
+ * These operations do not need to be highly optimized or fast
  */
 public interface ExperimentsStore {
     /**
      * Save an experiment, creating or updating it
+     *
      * @param experiment The experiment to create or update
      */
     void save(Experiment experiment);
 
     /**
      * Retrieves an experiment
+     *
      * @param experimentName The name of the experiment
      * @param builder The builder to use to construct the experiment
      * @return The experiment with the given name
@@ -23,12 +25,14 @@ public interface ExperimentsStore {
 
     /**
      * Deletes an experiment and its associated data
+     *
      * @param experimentName The name of the experiment
      */
     void delete(String experimentName);
 
     /**
      * Finds experiments with given criteria
+     *
      * @param filter Criteria for pagination and filtering
      * @return Filtered list of experiments
      */

--- a/alchemy-core/src/main/java/io/rtr/alchemy/db/ExperimentsStoreProvider.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/db/ExperimentsStoreProvider.java
@@ -2,10 +2,9 @@ package io.rtr.alchemy.db;
 
 import java.io.Closeable;
 
-/**
- * An interface for implementing a provider that is configurable
- */
+/** An interface for implementing a provider that is configurable */
 public interface ExperimentsStoreProvider extends Closeable {
     ExperimentsCache getCache();
+
     ExperimentsStore getStore();
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/db/Filter.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/db/Filter.java
@@ -3,9 +3,7 @@ package io.rtr.alchemy.db;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-/**
- * Filter criteria for a list query, allowing for pagination and filtering of items
- */
+/** Filter criteria for a list query, allowing for pagination and filtering of items */
 public class Filter {
     public static final Filter NONE = Filter.criteria().build();
     private final String filter;
@@ -84,18 +82,14 @@ public class Filter {
 
         final Filter other = (Filter) obj;
 
-        return
-            Objects.equal(filter, other.filter) &&
-            Objects.equal(offset, other.offset) &&
-            Objects.equal(limit, other.limit);
-
+        return Objects.equal(filter, other.filter)
+                && Objects.equal(offset, other.offset)
+                && Objects.equal(limit, other.limit);
     }
 
     @Override
     public String toString() {
-        return
-            MoreObjects
-                .toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("filter", filter)
                 .add("offset", offset)
                 .add("limit", limit)

--- a/alchemy-core/src/main/java/io/rtr/alchemy/db/Ordering.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/db/Ordering.java
@@ -7,9 +7,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-/**
- * Specifies how multiple fields are ordered
- */
+/** Specifies how multiple fields are ordered */
 public class Ordering {
     private final Map<Field, Direction> fields;
 
@@ -39,11 +37,7 @@ public class Ordering {
             final Direction direction = index > -1 ? Direction.DESCENDING : Direction.ASCENDING;
             final Field field = Field.fromName(token.substring(index + 1));
 
-            Preconditions.checkArgument(
-                field != null,
-                "Unsupported ordering field: %s",
-                token
-            );
+            Preconditions.checkArgument(field != null, "Unsupported ordering field: %s", token);
 
             fields.put(field, direction);
         }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterBaseListener.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterBaseListener.java
@@ -1,4 +1,4 @@
-// Generated from Filter.g4 by ANTLR 4.2.2
+// Generated from Filter.g4 by ANTLR 4.5
 package io.rtr.alchemy.filtering;
 
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -17,101 +17,96 @@ public class FilterBaseListener implements FilterListener {
 	 *
 	 * <p>The default implementation does nothing.</p>
 	 */
-	@Override public void enterComparison(@NotNull FilterParser.ComparisonContext ctx) { }
+	@Override public void enterExp(FilterParser.ExpContext ctx) { }
 	/**
 	 * {@inheritDoc}
 	 *
 	 * <p>The default implementation does nothing.</p>
 	 */
-	@Override public void exitComparison(@NotNull FilterParser.ComparisonContext ctx) { }
+	@Override public void exitExp(FilterParser.ExpContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void enterTerm(FilterParser.TermContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void exitTerm(FilterParser.TermContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void enterFactor(FilterParser.FactorContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void exitFactor(FilterParser.FactorContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void enterComparison(FilterParser.ComparisonContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void exitComparison(FilterParser.ComparisonContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void enterConstant(FilterParser.ConstantContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void exitConstant(FilterParser.ConstantContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void enterValue(FilterParser.ValueContext ctx) { }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation does nothing.</p>
+	 */
+	@Override public void exitValue(FilterParser.ValueContext ctx) { }
 
 	/**
 	 * {@inheritDoc}
 	 *
 	 * <p>The default implementation does nothing.</p>
 	 */
-	@Override public void enterConstant(@NotNull FilterParser.ConstantContext ctx) { }
+	@Override public void enterEveryRule(ParserRuleContext ctx) { }
 	/**
 	 * {@inheritDoc}
 	 *
 	 * <p>The default implementation does nothing.</p>
 	 */
-	@Override public void exitConstant(@NotNull FilterParser.ConstantContext ctx) { }
-
+	@Override public void exitEveryRule(ParserRuleContext ctx) { }
 	/**
 	 * {@inheritDoc}
 	 *
 	 * <p>The default implementation does nothing.</p>
 	 */
-	@Override public void enterTerm(@NotNull FilterParser.TermContext ctx) { }
+	@Override public void visitTerminal(TerminalNode node) { }
 	/**
 	 * {@inheritDoc}
 	 *
 	 * <p>The default implementation does nothing.</p>
 	 */
-	@Override public void exitTerm(@NotNull FilterParser.TermContext ctx) { }
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void enterExp(@NotNull FilterParser.ExpContext ctx) { }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void exitExp(@NotNull FilterParser.ExpContext ctx) { }
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void enterFactor(@NotNull FilterParser.FactorContext ctx) { }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void exitFactor(@NotNull FilterParser.FactorContext ctx) { }
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void enterValue(@NotNull FilterParser.ValueContext ctx) { }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void exitValue(@NotNull FilterParser.ValueContext ctx) { }
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void enterEveryRule(@NotNull ParserRuleContext ctx) { }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void exitEveryRule(@NotNull ParserRuleContext ctx) { }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void visitTerminal(@NotNull TerminalNode node) { }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation does nothing.</p>
-	 */
-	@Override public void visitErrorNode(@NotNull ErrorNode node) { }
+	@Override public void visitErrorNode(ErrorNode node) { }
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterErrorListener.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterErrorListener.java
@@ -13,22 +13,47 @@ import java.util.BitSet;
 
 public class FilterErrorListener implements ANTLRErrorListener {
     @Override
-    public void syntaxError(@NotNull Recognizer<?, ?> recognizer, @Nullable Object o, int i, int i2, @NotNull String s, @Nullable RecognitionException e) {
+    public void syntaxError(
+            @NotNull Recognizer<?, ?> recognizer,
+            @Nullable Object o,
+            int i,
+            int i2,
+            @NotNull String s,
+            @Nullable RecognitionException e) {
         throw new IllegalArgumentException(e);
     }
 
     @Override
-    public void reportAmbiguity(@NotNull Parser parser, @NotNull DFA dfa, int i, int i2, boolean b, @Nullable BitSet bitSet, @NotNull ATNConfigSet atnConfigs) {
+    public void reportAmbiguity(
+            @NotNull Parser parser,
+            @NotNull DFA dfa,
+            int i,
+            int i2,
+            boolean b,
+            @Nullable BitSet bitSet,
+            @NotNull ATNConfigSet atnConfigs) {
         throw new IllegalArgumentException("ambiguity");
     }
 
     @Override
-    public void reportAttemptingFullContext(@NotNull Parser parser, @NotNull DFA dfa, int i, int i2, @Nullable BitSet bitSet, @NotNull ATNConfigSet atnConfigs) {
+    public void reportAttemptingFullContext(
+            @NotNull Parser parser,
+            @NotNull DFA dfa,
+            int i,
+            int i2,
+            @Nullable BitSet bitSet,
+            @NotNull ATNConfigSet atnConfigs) {
         throw new IllegalArgumentException("ambiguity");
     }
 
     @Override
-    public void reportContextSensitivity(@NotNull Parser parser, @NotNull DFA dfa, int i, int i2, int i3, @NotNull ATNConfigSet atnConfigs) {
+    public void reportContextSensitivity(
+            @NotNull Parser parser,
+            @NotNull DFA dfa,
+            int i,
+            int i2,
+            int i3,
+            @NotNull ATNConfigSet atnConfigs) {
         throw new IllegalArgumentException("ambiguity");
     }
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterExpression.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterExpression.java
@@ -12,9 +12,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.Stack;
 
-/**
- * Allows evaluation of a filter expression which tests whether given attributes are present
- */
+/** Allows evaluation of a filter expression which tests whether given attributes are present */
 public class FilterExpression {
     private static final FilterExpression ALWAYS_TRUE = new FilterExpression();
     private static final FilterErrorListener ERROR_LISTENER = new FilterErrorListener();
@@ -58,6 +56,7 @@ public class FilterExpression {
 
     /**
      * Evaluates the filter
+     *
      * @param attributes Attributes to evaluate against
      */
     public boolean evaluate(AttributesMap attributes) {
@@ -100,11 +99,11 @@ public class FilterExpression {
     }
 
     /**
-     * A parser listener that evaluates the boolean logic expression by traversing the tree
-     * Each time an operation is encountered (e.g. exp, factor or term), we push onto the stack
-     * OP to serve as a place holder to separate contiguous values that should be applied to an
-     * operation. Comparisons are evaluated when exiting a comparison, the boolean value of which
-     * is then pushed onto the stack as well
+     * A parser listener that evaluates the boolean logic expression by traversing the tree Each
+     * time an operation is encountered (e.g. exp, factor or term), we push onto the stack OP to
+     * serve as a place holder to separate contiguous values that should be applied to an operation.
+     * Comparisons are evaluated when exiting a comparison, the boolean value of which is then
+     * pushed onto the stack as well
      */
     private static class FilterExpressionEvaluator implements FilterListener {
         private static final Boolean OP = null;
@@ -215,43 +214,31 @@ public class FilterExpression {
         }
 
         @Override
-        public void enterValue(@NotNull FilterParser.ValueContext ctx) {
-        }
+        public void enterValue(@NotNull FilterParser.ValueContext ctx) {}
 
         @Override
-        public void exitValue(@NotNull FilterParser.ValueContext ctx) {
-        }
+        public void exitValue(@NotNull FilterParser.ValueContext ctx) {}
 
         @Override
-        public void visitTerminal(@NotNull TerminalNode terminalNode) {
-
-        }
+        public void visitTerminal(@NotNull TerminalNode terminalNode) {}
 
         @Override
-        public void visitErrorNode(@NotNull ErrorNode errorNode) {
-
-        }
+        public void visitErrorNode(@NotNull ErrorNode errorNode) {}
 
         @Override
-        public void enterEveryRule(@NotNull ParserRuleContext parserRuleContext) {
-
-        }
+        public void enterEveryRule(@NotNull ParserRuleContext parserRuleContext) {}
 
         @Override
-        public void exitEveryRule(@NotNull ParserRuleContext parserRuleContext) {
-        }
+        public void exitEveryRule(@NotNull ParserRuleContext parserRuleContext) {}
 
         @Override
-        public void enterConstant(@NotNull FilterParser.ConstantContext ctx) {
-        }
+        public void enterConstant(@NotNull FilterParser.ConstantContext ctx) {}
 
         @Override
-        public void exitConstant(@NotNull FilterParser.ConstantContext ctx) {
-        }
+        public void exitConstant(@NotNull FilterParser.ConstantContext ctx) {}
 
         @Override
-        public void enterComparison(@NotNull FilterParser.ComparisonContext ctx) {
-        }
+        public void enterComparison(@NotNull FilterParser.ComparisonContext ctx) {}
 
         private Class<?> getType(FilterParser.ValueContext context) {
             if (context.IDENTIFIER() != null) {
@@ -291,9 +278,7 @@ public class FilterExpression {
                 final FilterParser.ConstantContext constant = context.constant();
                 if (constant.STRING() != null) {
                     final String value = constant.STRING().getText();
-                    return value.length() == 2 ?
-                           "" :
-                           value.substring(1, value.length() - 1);
+                    return value.length() == 2 ? "" : value.substring(1, value.length() - 1);
                 } else if (constant.NUMBER() != null) {
                     return Long.parseLong(constant.NUMBER().getText());
                 } else if (constant.BOOLEAN() != null) {

--- a/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterLexer.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterLexer.java
@@ -1,4 +1,4 @@
-// Generated from Filter.g4 by ANTLR 4.2.2
+// Generated from Filter.g4 by ANTLR 4.5
 package io.rtr.alchemy.filtering;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.CharStream;
@@ -11,25 +11,62 @@ import org.antlr.v4.runtime.misc.*;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class FilterLexer extends Lexer {
+	static { RuntimeMetaData.checkVersion("4.5", RuntimeMetaData.VERSION); }
+
 	protected static final DFA[] _decisionToDFA;
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
 	public static final int
-		T__1=1, T__0=2, AND=3, OR=4, NOT=5, NUMBER=6, STRING=7, BOOLEAN=8, IDENTIFIER=9, 
+		T__0=1, T__1=2, AND=3, OR=4, NOT=5, NUMBER=6, STRING=7, BOOLEAN=8, IDENTIFIER=9, 
 		COMPARISON=10, WS=11;
 	public static String[] modeNames = {
 		"DEFAULT_MODE"
 	};
 
-	public static final String[] tokenNames = {
-		"<INVALID>",
-		"'('", "')'", "AND", "OR", "NOT", "NUMBER", "STRING", "BOOLEAN", "IDENTIFIER", 
-		"COMPARISON", "WS"
-	};
 	public static final String[] ruleNames = {
-		"T__1", "T__0", "AND", "OR", "NOT", "NUMBER", "STRING", "BOOLEAN", "IDENTIFIER", 
+		"T__0", "T__1", "AND", "OR", "NOT", "NUMBER", "STRING", "BOOLEAN", "IDENTIFIER", 
 		"COMPARISON", "WS"
 	};
+
+	private static final String[] _LITERAL_NAMES = {
+		null, "'('", "')'"
+	};
+	private static final String[] _SYMBOLIC_NAMES = {
+		null, null, null, "AND", "OR", "NOT", "NUMBER", "STRING", "BOOLEAN", "IDENTIFIER", 
+		"COMPARISON", "WS"
+	};
+	public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
+
+	/**
+	 * @deprecated Use {@link #VOCABULARY} instead.
+	 */
+	@Deprecated
+	public static final String[] tokenNames;
+	static {
+		tokenNames = new String[_SYMBOLIC_NAMES.length];
+		for (int i = 0; i < tokenNames.length; i++) {
+			tokenNames[i] = VOCABULARY.getLiteralName(i);
+			if (tokenNames[i] == null) {
+				tokenNames[i] = VOCABULARY.getSymbolicName(i);
+			}
+
+			if (tokenNames[i] == null) {
+				tokenNames[i] = "<INVALID>";
+			}
+		}
+	}
+
+	@Override
+	@Deprecated
+	public String[] getTokenNames() {
+		return tokenNames;
+	}
+
+	@Override
+
+	public Vocabulary getVocabulary() {
+		return VOCABULARY;
+	}
 
 
 	public FilterLexer(CharStream input) {
@@ -39,9 +76,6 @@ public class FilterLexer extends Lexer {
 
 	@Override
 	public String getGrammarFileName() { return "Filter.g4"; }
-
-	@Override
-	public String[] getTokenNames() { return tokenNames; }
 
 	@Override
 	public String[] getRuleNames() { return ruleNames; }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterListener.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterListener.java
@@ -1,4 +1,4 @@
-// Generated from Filter.g4 by ANTLR 4.2.2
+// Generated from Filter.g4 by ANTLR 4.5
 package io.rtr.alchemy.filtering;
 import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
@@ -9,68 +9,63 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
  */
 public interface FilterListener extends ParseTreeListener {
 	/**
-	 * Enter a parse tree produced by {@link FilterParser#comparison}.
-	 * @param ctx the parse tree
-	 */
-	void enterComparison(@NotNull FilterParser.ComparisonContext ctx);
-	/**
-	 * Exit a parse tree produced by {@link FilterParser#comparison}.
-	 * @param ctx the parse tree
-	 */
-	void exitComparison(@NotNull FilterParser.ComparisonContext ctx);
-
-	/**
-	 * Enter a parse tree produced by {@link FilterParser#constant}.
-	 * @param ctx the parse tree
-	 */
-	void enterConstant(@NotNull FilterParser.ConstantContext ctx);
-	/**
-	 * Exit a parse tree produced by {@link FilterParser#constant}.
-	 * @param ctx the parse tree
-	 */
-	void exitConstant(@NotNull FilterParser.ConstantContext ctx);
-
-	/**
-	 * Enter a parse tree produced by {@link FilterParser#term}.
-	 * @param ctx the parse tree
-	 */
-	void enterTerm(@NotNull FilterParser.TermContext ctx);
-	/**
-	 * Exit a parse tree produced by {@link FilterParser#term}.
-	 * @param ctx the parse tree
-	 */
-	void exitTerm(@NotNull FilterParser.TermContext ctx);
-
-	/**
 	 * Enter a parse tree produced by {@link FilterParser#exp}.
 	 * @param ctx the parse tree
 	 */
-	void enterExp(@NotNull FilterParser.ExpContext ctx);
+	void enterExp(FilterParser.ExpContext ctx);
 	/**
 	 * Exit a parse tree produced by {@link FilterParser#exp}.
 	 * @param ctx the parse tree
 	 */
-	void exitExp(@NotNull FilterParser.ExpContext ctx);
-
+	void exitExp(FilterParser.ExpContext ctx);
+	/**
+	 * Enter a parse tree produced by {@link FilterParser#term}.
+	 * @param ctx the parse tree
+	 */
+	void enterTerm(FilterParser.TermContext ctx);
+	/**
+	 * Exit a parse tree produced by {@link FilterParser#term}.
+	 * @param ctx the parse tree
+	 */
+	void exitTerm(FilterParser.TermContext ctx);
 	/**
 	 * Enter a parse tree produced by {@link FilterParser#factor}.
 	 * @param ctx the parse tree
 	 */
-	void enterFactor(@NotNull FilterParser.FactorContext ctx);
+	void enterFactor(FilterParser.FactorContext ctx);
 	/**
 	 * Exit a parse tree produced by {@link FilterParser#factor}.
 	 * @param ctx the parse tree
 	 */
-	void exitFactor(@NotNull FilterParser.FactorContext ctx);
-
+	void exitFactor(FilterParser.FactorContext ctx);
+	/**
+	 * Enter a parse tree produced by {@link FilterParser#comparison}.
+	 * @param ctx the parse tree
+	 */
+	void enterComparison(FilterParser.ComparisonContext ctx);
+	/**
+	 * Exit a parse tree produced by {@link FilterParser#comparison}.
+	 * @param ctx the parse tree
+	 */
+	void exitComparison(FilterParser.ComparisonContext ctx);
+	/**
+	 * Enter a parse tree produced by {@link FilterParser#constant}.
+	 * @param ctx the parse tree
+	 */
+	void enterConstant(FilterParser.ConstantContext ctx);
+	/**
+	 * Exit a parse tree produced by {@link FilterParser#constant}.
+	 * @param ctx the parse tree
+	 */
+	void exitConstant(FilterParser.ConstantContext ctx);
 	/**
 	 * Enter a parse tree produced by {@link FilterParser#value}.
 	 * @param ctx the parse tree
 	 */
-	void enterValue(@NotNull FilterParser.ValueContext ctx);
+	void enterValue(FilterParser.ValueContext ctx);
 	/**
 	 * Exit a parse tree produced by {@link FilterParser#value}.
 	 * @param ctx the parse tree
 	 */
-	void exitValue(@NotNull FilterParser.ValueContext ctx);
+	void exitValue(FilterParser.ValueContext ctx);
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterParser.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/filtering/FilterParser.java
@@ -1,4 +1,4 @@
-// Generated from Filter.g4 by ANTLR 4.2.2
+// Generated from Filter.g4 by ANTLR 4.5
 package io.rtr.alchemy.filtering;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
@@ -11,16 +11,14 @@ import java.util.ArrayList;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class FilterParser extends Parser {
+	static { RuntimeMetaData.checkVersion("4.5", RuntimeMetaData.VERSION); }
+
 	protected static final DFA[] _decisionToDFA;
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
 	public static final int
-		T__1=1, T__0=2, AND=3, OR=4, NOT=5, NUMBER=6, STRING=7, BOOLEAN=8, IDENTIFIER=9, 
+		T__0=1, T__1=2, AND=3, OR=4, NOT=5, NUMBER=6, STRING=7, BOOLEAN=8, IDENTIFIER=9, 
 		COMPARISON=10, WS=11;
-	public static final String[] tokenNames = {
-		"<INVALID>", "'('", "')'", "AND", "OR", "NOT", "NUMBER", "STRING", "BOOLEAN", 
-		"IDENTIFIER", "COMPARISON", "WS"
-	};
 	public static final int
 		RULE_exp = 0, RULE_term = 1, RULE_factor = 2, RULE_comparison = 3, RULE_constant = 4, 
 		RULE_value = 5;
@@ -28,11 +26,48 @@ public class FilterParser extends Parser {
 		"exp", "term", "factor", "comparison", "constant", "value"
 	};
 
-	@Override
-	public String getGrammarFileName() { return "Filter.g4"; }
+	private static final String[] _LITERAL_NAMES = {
+		null, "'('", "')'"
+	};
+	private static final String[] _SYMBOLIC_NAMES = {
+		null, null, null, "AND", "OR", "NOT", "NUMBER", "STRING", "BOOLEAN", "IDENTIFIER", 
+		"COMPARISON", "WS"
+	};
+	public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
+
+	/**
+	 * @deprecated Use {@link #VOCABULARY} instead.
+	 */
+	@Deprecated
+	public static final String[] tokenNames;
+	static {
+		tokenNames = new String[_SYMBOLIC_NAMES.length];
+		for (int i = 0; i < tokenNames.length; i++) {
+			tokenNames[i] = VOCABULARY.getLiteralName(i);
+			if (tokenNames[i] == null) {
+				tokenNames[i] = VOCABULARY.getSymbolicName(i);
+			}
+
+			if (tokenNames[i] == null) {
+				tokenNames[i] = "<INVALID>";
+			}
+		}
+	}
 
 	@Override
-	public String[] getTokenNames() { return tokenNames; }
+	@Deprecated
+	public String[] getTokenNames() {
+		return tokenNames;
+	}
+
+	@Override
+
+	public Vocabulary getVocabulary() {
+		return VOCABULARY;
+	}
+
+	@Override
+	public String getGrammarFileName() { return "Filter.g4"; }
 
 	@Override
 	public String[] getRuleNames() { return ruleNames; }
@@ -48,11 +83,11 @@ public class FilterParser extends Parser {
 		_interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
 	}
 	public static class ExpContext extends ParserRuleContext {
-		public ExpContext exp() {
-			return getRuleContext(ExpContext.class,0);
-		}
 		public TermContext term() {
 			return getRuleContext(TermContext.class,0);
+		}
+		public ExpContext exp() {
+			return getRuleContext(ExpContext.class,0);
 		}
 		public TerminalNode OR() { return getToken(FilterParser.OR, 0); }
 		public ExpContext(ParserRuleContext parent, int invokingState) {
@@ -85,13 +120,14 @@ public class FilterParser extends Parser {
 			enterOuterAlt(_localctx, 1);
 			{
 			{
-			setState(13); term();
+			setState(13);
+			term();
 			}
 			_ctx.stop = _input.LT(-1);
 			setState(20);
 			_errHandler.sync(this);
 			_alt = getInterpreter().adaptivePredict(_input,0,_ctx);
-			while ( _alt!=2 && _alt!=ATN.INVALID_ALT_NUMBER ) {
+			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					if ( _parseListeners!=null ) triggerExitRuleEvent();
 					_prevctx = _localctx;
@@ -101,8 +137,10 @@ public class FilterParser extends Parser {
 					pushNewRecursionContext(_localctx, _startState, RULE_exp);
 					setState(15);
 					if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-					setState(16); match(OR);
-					setState(17); term();
+					setState(16);
+					match(OR);
+					setState(17);
+					term();
 					}
 					} 
 				}
@@ -127,10 +165,10 @@ public class FilterParser extends Parser {
 		public FactorContext factor() {
 			return getRuleContext(FactorContext.class,0);
 		}
+		public TerminalNode AND() { return getToken(FilterParser.AND, 0); }
 		public TermContext term() {
 			return getRuleContext(TermContext.class,0);
 		}
-		public TerminalNode AND() { return getToken(FilterParser.AND, 0); }
 		public TermContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
@@ -154,16 +192,19 @@ public class FilterParser extends Parser {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(23); factor();
+				setState(23);
+				factor();
 				}
 				break;
-
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(24); factor();
-				setState(25); match(AND);
-				setState(26); term();
+				setState(24);
+				factor();
+				setState(25);
+				match(AND);
+				setState(26);
+				term();
 				}
 				break;
 			}
@@ -183,15 +224,15 @@ public class FilterParser extends Parser {
 		public ExpContext exp() {
 			return getRuleContext(ExpContext.class,0);
 		}
-		public TerminalNode NOT() { return getToken(FilterParser.NOT, 0); }
 		public ValueContext value() {
 			return getRuleContext(ValueContext.class,0);
 		}
-		public FactorContext factor() {
-			return getRuleContext(FactorContext.class,0);
-		}
 		public ComparisonContext comparison() {
 			return getRuleContext(ComparisonContext.class,0);
+		}
+		public TerminalNode NOT() { return getToken(FilterParser.NOT, 0); }
+		public FactorContext factor() {
+			return getRuleContext(FactorContext.class,0);
 		}
 		public FactorContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
@@ -216,31 +257,35 @@ public class FilterParser extends Parser {
 			case 1:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(30); match(1);
-				setState(31); exp(0);
-				setState(32); match(2);
+				setState(30);
+				match(T__0);
+				setState(31);
+				exp(0);
+				setState(32);
+				match(T__1);
 				}
 				break;
-
 			case 2:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(34); value();
+				setState(34);
+				value();
 				}
 				break;
-
 			case 3:
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(35); comparison();
+				setState(35);
+				comparison();
 				}
 				break;
-
 			case 4:
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(36); match(NOT);
-				setState(37); factor();
+				setState(36);
+				match(NOT);
+				setState(37);
+				factor();
 				}
 				break;
 			}
@@ -284,9 +329,12 @@ public class FilterParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(40); value();
-			setState(41); match(COMPARISON);
-			setState(42); value();
+			setState(40);
+			value();
+			setState(41);
+			match(COMPARISON);
+			setState(42);
+			value();
 			}
 		}
 		catch (RecognitionException re) {
@@ -301,9 +349,9 @@ public class FilterParser extends Parser {
 	}
 
 	public static class ConstantContext extends ParserRuleContext {
-		public TerminalNode STRING() { return getToken(FilterParser.STRING, 0); }
 		public TerminalNode BOOLEAN() { return getToken(FilterParser.BOOLEAN, 0); }
 		public TerminalNode NUMBER() { return getToken(FilterParser.NUMBER, 0); }
+		public TerminalNode STRING() { return getToken(FilterParser.STRING, 0); }
 		public ConstantContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
@@ -329,8 +377,9 @@ public class FilterParser extends Parser {
 			_la = _input.LA(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << NUMBER) | (1L << STRING) | (1L << BOOLEAN))) != 0)) ) {
 			_errHandler.recoverInline(this);
+			} else {
+				consume();
 			}
-			consume();
 			}
 		}
 		catch (RecognitionException re) {
@@ -374,13 +423,15 @@ public class FilterParser extends Parser {
 			case BOOLEAN:
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(46); constant();
+				setState(46);
+				constant();
 				}
 				break;
 			case IDENTIFIER:
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(47); match(IDENTIFIER);
+				setState(47);
+				match(IDENTIFIER);
 				}
 				break;
 			default:
@@ -400,13 +451,15 @@ public class FilterParser extends Parser {
 
 	public boolean sempred(RuleContext _localctx, int ruleIndex, int predIndex) {
 		switch (ruleIndex) {
-		case 0: return exp_sempred((ExpContext)_localctx, predIndex);
+		case 0:
+			return exp_sempred((ExpContext)_localctx, predIndex);
 		}
 		return true;
 	}
 	private boolean exp_sempred(ExpContext _localctx, int predIndex) {
 		switch (predIndex) {
-		case 0: return precpred(_ctx, 1);
+		case 0:
+			return precpred(_ctx, 1);
 		}
 		return true;
 	}

--- a/alchemy-core/src/main/java/io/rtr/alchemy/identities/Attributes.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/identities/Attributes.java
@@ -5,12 +5,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Annotates an identity with a list of supported attributes it may generate
- */
+/** Annotates an identity with a list of supported attributes it may generate */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Attributes {
     String[] value() default {};
+
     Class<? extends Identity>[] identities() default {};
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/identities/AttributesMap.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/identities/AttributesMap.java
@@ -165,14 +165,14 @@ public class AttributesMap implements Map<String, Object> {
 
         public Builder put(String name, boolean value) {
             builder.put(name, value);
-            return  this;
+            return this;
         }
 
         public Builder put(Identity identity) {
             if (identity != null) {
                 builder.putAll(identity.computeAttributes().values);
             }
-            return  this;
+            return this;
         }
 
         public AttributesMap build() {

--- a/alchemy-core/src/main/java/io/rtr/alchemy/identities/Identity.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/identities/Identity.java
@@ -10,42 +10,46 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-/**
- * Identifies a unique entity whose hash code is used for treatments allocation
- */
+/** Identifies a unique entity whose hash code is used for treatments allocation */
 public abstract class Identity {
-    protected static final Set<String> EMPTY = Collections.unmodifiableSet(Sets.<String>newHashSet());
+    protected static final Set<String> EMPTY =
+            Collections.unmodifiableSet(Sets.<String>newHashSet());
     private static final LoadingCache<Class<?>, Set<String>> ATTRIBUTES_CACHE =
-        CacheBuilder
-            .newBuilder()
-            .build(new CacheLoader<Class<?>, Set<String>>() {
-                @Override
-                public Set<String> load(@Nonnull Class<?> clazz) throws Exception {
-                    final Attributes annotation = clazz.getAnnotation(Attributes.class);
-                    if (annotation == null) {
-                        return EMPTY;
-                    }
+            CacheBuilder.newBuilder()
+                    .build(
+                            new CacheLoader<Class<?>, Set<String>>() {
+                                @Override
+                                public Set<String> load(@Nonnull Class<?> clazz) throws Exception {
+                                    final Attributes annotation =
+                                            clazz.getAnnotation(Attributes.class);
+                                    if (annotation == null) {
+                                        return EMPTY;
+                                    }
 
-                    final Set<String> result = Sets.newHashSet();
-                    Collections.addAll(result, annotation.value());
+                                    final Set<String> result = Sets.newHashSet();
+                                    Collections.addAll(result, annotation.value());
 
-                    for (final Class<? extends Identity> identity : annotation.identities()) {
-                        result.addAll(ATTRIBUTES_CACHE.get(identity));
-                    }
+                                    for (final Class<? extends Identity> identity :
+                                            annotation.identities()) {
+                                        result.addAll(ATTRIBUTES_CACHE.get(identity));
+                                    }
 
-                    return result;
-                }
-            });
+                                    return result;
+                                }
+                            });
 
     /**
      * generates a hash code used to assign identity to treatment
-     * @param seed a seed value to randomize the resulting hash from experiment to experiment for the same identity
+     *
+     * @param seed a seed value to randomize the resulting hash from experiment to experiment for
+     *     the same identity
      * @param hashAttributes a set of attributes that should be used to compute the hash code
      * @param attributes a map of attribute values
      */
     public long computeHash(int seed, Set<String> hashAttributes, AttributesMap attributes) {
         final IdentityBuilder builder = IdentityBuilder.seed(seed);
-        final Iterable<String> names = hashAttributes.isEmpty() ? attributes.keySet() : hashAttributes;
+        final Iterable<String> names =
+                hashAttributes.isEmpty() ? attributes.keySet() : hashAttributes;
 
         for (String name : names) {
             final Class<?> type = attributes.getType(name);
@@ -62,28 +66,20 @@ public abstract class Identity {
         return builder.hash();
     }
 
-    /**
-     * generates a list of attributes that describe this identity for filtering
-     */
+    /** generates a list of attributes that describe this identity for filtering */
     public abstract AttributesMap computeAttributes();
 
-    /**
-     * Convenience method for getting an identity builder given a seed
-     */
+    /** Convenience method for getting an identity builder given a seed */
     protected IdentityBuilder identity(int seed) {
         return IdentityBuilder.seed(seed);
     }
 
-    /**
-     * Convenience method for getting an attributes map builder
-     */
+    /** Convenience method for getting an attributes map builder */
     protected AttributesMap.Builder attributes() {
         return AttributesMap.newBuilder();
     }
 
-    /**
-     * Get a list of possible attribute values that can be returned by this identity
-     */
+    /** Get a list of possible attribute values that can be returned by this identity */
     public static <T extends Identity> Set<String> getSupportedAttributes(Class<T> clazz) {
         try {
             return ATTRIBUTES_CACHE.get(clazz);

--- a/alchemy-core/src/main/java/io/rtr/alchemy/identities/IdentityBuilder.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/identities/IdentityBuilder.java
@@ -5,9 +5,7 @@ import com.google.common.hash.Hashing;
 
 import java.nio.charset.Charset;
 
-/**
- * Used for building a unique identity
- */
+/** Used for building a unique identity */
 public class IdentityBuilder {
     private static final Charset CHARSET = Charset.forName("UTF-8");
     private final Hasher hasher;

--- a/alchemy-core/src/main/java/io/rtr/alchemy/models/Allocation.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/models/Allocation.java
@@ -3,9 +3,7 @@ package io.rtr.alchemy.models;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-/**
- * Represents a contiguous allocation block of a single treatment in an experiment
- */
+/** Represents a contiguous allocation block of a single treatment in an experiment */
 public class Allocation {
     private final Treatment treatment;
     private final int offset;
@@ -37,10 +35,9 @@ public class Allocation {
 
         final Allocation other = (Allocation) obj;
 
-        return
-            Objects.equal(treatment, other.treatment) &&
-            Objects.equal(offset, other.offset) &&
-            Objects.equal(size, other.size);
+        return Objects.equal(treatment, other.treatment)
+                && Objects.equal(offset, other.offset)
+                && Objects.equal(size, other.size);
     }
 
     @Override
@@ -50,9 +47,7 @@ public class Allocation {
 
     @Override
     public String toString() {
-        return
-            MoreObjects
-                .toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("treatment", treatment)
                 .add("offset", offset)
                 .add("size", size)

--- a/alchemy-core/src/main/java/io/rtr/alchemy/models/Allocations.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/models/Allocations.java
@@ -12,17 +12,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-/**
- * Represents allocations of treatments for an experiment
- */
+/** Represents allocations of treatments for an experiment */
 public class Allocations {
     public static final int NUM_BINS = 100;
-    private static final Comparator<Allocation> COMPARATOR = new Comparator<Allocation>() {
-        @Override
-        public int compare(Allocation lhs, Allocation rhs) {
-            return Integer.compare(lhs.getOffset(), rhs.getOffset());
-        }
-    };
+    private static final Comparator<Allocation> COMPARATOR =
+            new Comparator<Allocation>() {
+                @Override
+                public int compare(Allocation lhs, Allocation rhs) {
+                    return Integer.compare(lhs.getOffset(), rhs.getOffset());
+                }
+            };
 
     private Byte[] allocationMap;
     private List<Allocation> allocations;
@@ -55,11 +54,10 @@ public class Allocations {
                 treatments.put(allocation.getTreatment(), treatment);
             }
 
-            for (int i=allocation.getOffset(); i<allocation.getOffset() + allocation.getSize(); i++, size++) {
-                Preconditions.checkState(
-                    allocationMap[i] == null,
-                    "overlapping allocations"
-                );
+            for (int i = allocation.getOffset();
+                    i < allocation.getOffset() + allocation.getSize();
+                    i++, size++) {
+                Preconditions.checkState(allocationMap[i] == null, "overlapping allocations");
                 allocationMap[i] = treatment.byteValue();
             }
         }
@@ -73,6 +71,7 @@ public class Allocations {
 
     /**
      * Get treatment assigned to a specific bin
+     *
      * @param bin The bin
      */
     public Treatment getTreatment(int bin) {
@@ -97,7 +96,7 @@ public class Allocations {
         int offset = allocations.get(0).getOffset();
         Treatment treatment = allocations.get(0).getTreatment();
 
-        for (int i=1; i<allocations.size(); i++) {
+        for (int i = 1; i < allocations.size(); i++) {
             final Allocation allocation = allocations.get(i);
             if (!allocation.getTreatment().equals(treatment)) {
                 // different treatment
@@ -117,17 +116,17 @@ public class Allocations {
 
     /**
      * Allocates bins to a treatment
+     *
      * @param treatment The treatment
      * @param size The number of bins
      */
     public void allocate(Treatment treatment, int size) {
         Preconditions.checkArgument(
-            getUnallocatedSize() >= size,
-            "not enough free bins to allocate treatment %s with size %s given %s unallocated bin(s)",
-            treatment.getName(),
-            size,
-            getUnallocatedSize()
-        );
+                getUnallocatedSize() >= size,
+                "not enough free bins to allocate treatment %s with size %s given %s unallocated bin(s)",
+                treatment.getName(),
+                size,
+                getUnallocatedSize());
 
         // turn contiguous unallocated blocks into allocated blocks
         final List<Allocation> pieces = Lists.newArrayList();
@@ -159,6 +158,7 @@ public class Allocations {
 
     /**
      * De-allocates bins from a treatment
+     *
      * @param treatment The treatment
      * @param size The number of bins
      */
@@ -175,8 +175,13 @@ public class Allocations {
             }
 
             if (sizeLeft < 0) {
-                // a piece could not be evenly split by the amount we wanted to deallocate, need to add back in
-                allocations.add(new Allocation(treatment, next.getOffset() + next.getSize() + sizeLeft, -sizeLeft));
+                // a piece could not be evenly split by the amount we wanted to deallocate, need to
+                // add back in
+                allocations.add(
+                        new Allocation(
+                                treatment,
+                                next.getOffset() + next.getSize() + sizeLeft,
+                                -sizeLeft));
                 break;
             }
         }
@@ -188,6 +193,7 @@ public class Allocations {
 
     /**
      * Reallocates bins from one treatment to another
+     *
      * @param source The source treatment
      * @param destination The destination treatment
      * @param size The number of bins
@@ -210,9 +216,13 @@ public class Allocations {
             iter.remove();
 
             if (sizeLeft < 0) {
-                // a piece could not be evenly split by the amount we wanted to deallocate, need to add back in
-                pieces.add(new Allocation(destination, next.getOffset(), next.getSize() + sizeLeft));
-                pieces.add(new Allocation(source, next.getOffset() + next.getSize() + sizeLeft, -sizeLeft));
+                // a piece could not be evenly split by the amount we wanted to deallocate, need to
+                // add back in
+                pieces.add(
+                        new Allocation(destination, next.getOffset(), next.getSize() + sizeLeft));
+                pieces.add(
+                        new Allocation(
+                                source, next.getOffset() + next.getSize() + sizeLeft, -sizeLeft));
             } else {
                 pieces.add(new Allocation(destination, next.getOffset(), next.getSize()));
             }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/models/Experiment.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/models/Experiment.java
@@ -27,20 +27,17 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Represents a collection of user experiences being tested
- */
-
+/** Represents a collection of user experiences being tested */
 public class Experiment implements Named {
     private static final Set<String> EMPTY_SET = Sets.newLinkedHashSet();
     private static final Function<TreatmentOverride, String> TREATMENT_INDEXER =
-        new Function<TreatmentOverride, String>() {
-            @Nullable
-            @Override
-            public String apply(@Nullable TreatmentOverride input) {
-                return input != null ? input.getName() : null;
-            }
-        };
+            new Function<TreatmentOverride, String>() {
+                @Nullable
+                @Override
+                public String apply(@Nullable TreatmentOverride input) {
+                    return input != null ? input.getName() : null;
+                }
+            };
 
     private final Experiments owner;
     private final String name;
@@ -58,20 +55,21 @@ public class Experiment implements Named {
     private DateTime deactivated;
 
     // used by Builder when loading experiment from store
-    private Experiment(Experiments owner,
-                       String name,
-                       int seed,
-                       String description,
-                       FilterExpression filter,
-                       Set<String> hashAttributes,
-                       boolean active,
-                       DateTime created,
-                       DateTime modified,
-                       DateTime activated,
-                       DateTime deactivated,
-                       Map<String, Treatment> treatments,
-                       Iterable<TreatmentOverride> overrides,
-                       Iterable<Allocation> allocations) {
+    private Experiment(
+            Experiments owner,
+            String name,
+            int seed,
+            String description,
+            FilterExpression filter,
+            Set<String> hashAttributes,
+            boolean active,
+            DateTime created,
+            DateTime modified,
+            DateTime activated,
+            DateTime deactivated,
+            Map<String, Treatment> treatments,
+            Iterable<TreatmentOverride> overrides,
+            Iterable<Allocation> allocations) {
         this.owner = owner;
         this.name = name;
         this.description = description;
@@ -101,7 +99,7 @@ public class Experiment implements Named {
     }
 
     public static Experiment copyOf(Experiment experiment) throws ValidationException {
-        return  experiment != null ? new Experiment(experiment) : null;
+        return experiment != null ? new Experiment(experiment) : null;
     }
 
     private Experiment(Experiment toCopy) throws ValidationException {
@@ -110,13 +108,16 @@ public class Experiment implements Named {
 
         this.treatments = Maps.newConcurrentMap();
         for (final Treatment treatment : toCopy.getTreatments()) {
-            this.treatments.put(treatment.getName(), new Treatment(treatment.getName(), treatment.getDescription()));
+            this.treatments.put(
+                    treatment.getName(),
+                    new Treatment(treatment.getName(), treatment.getDescription()));
         }
 
         final List<Allocation> allocations = Lists.newArrayList();
         for (final Allocation allocation : toCopy.getAllocations()) {
             final Treatment treatment = this.treatments.get(allocation.getTreatment().getName());
-            allocations.add(new Allocation(treatment, allocation.getOffset(), allocation.getSize()));
+            allocations.add(
+                    new Allocation(treatment, allocation.getOffset(), allocation.getSize()));
         }
 
         this.allocations = new Allocations(allocations);
@@ -124,7 +125,8 @@ public class Experiment implements Named {
         this.overrides = Maps.newConcurrentMap();
         for (final TreatmentOverride override : toCopy.getOverrides()) {
             final Treatment treatment = this.treatments.get(override.getTreatment().getName());
-            final TreatmentOverride newOverride =  new TreatmentOverride(override.getName(), override.getFilter(), treatment);
+            final TreatmentOverride newOverride =
+                    new TreatmentOverride(override.getName(), override.getFilter(), treatment);
             overrides.put(override.getName(), newOverride);
         }
 
@@ -174,7 +176,7 @@ public class Experiment implements Named {
         return this;
     }
 
-    public Experiment setHashAttributes(String ... hashAttributes) {
+    public Experiment setHashAttributes(String... hashAttributes) {
         if (hashAttributes == null) {
             this.hashAttributes = EMPTY_SET;
         } else {
@@ -184,7 +186,8 @@ public class Experiment implements Named {
     }
 
     /**
-     * Sets the seed used to compute hashes from identities. WARNING: Changing this value will change what users are assigned to what treatments
+     * Sets the seed used to compute hashes from identities. WARNING: Changing this value will
+     * change what users are assigned to what treatments
      */
     public Experiment setSeed(int seed) {
         this.seed = seed;
@@ -215,45 +218,36 @@ public class Experiment implements Named {
         return deactivated;
     }
 
-    /**
-     * Gets all allocations defined on this experiment
-     */
+    /** Gets all allocations defined on this experiment */
     public List<Allocation> getAllocations() {
         return Collections.unmodifiableList(allocations.getAllocations());
     }
 
-    /**
-     * Gets all treatments defined on this experiment
-     */
+    /** Gets all treatments defined on this experiment */
     public List<Treatment> getTreatments() {
         return Collections.unmodifiableList(Lists.newArrayList(treatments.values()));
     }
 
-    /**
-     * Get a treatment with the given name
-     */
+    /** Get a treatment with the given name */
     public Treatment getTreatment(String treatmentName) {
         return treatments.get(treatmentName);
     }
 
-    /**
-     * Gets all overrides defined on this experiment
-     */
+    /** Gets all overrides defined on this experiment */
     public List<TreatmentOverride> getOverrides() {
         return ImmutableList.copyOf(overrides.values());
     }
 
     /**
      * Gets the assigned override for a given name
+     *
      * @param overrideName The name
      */
     public TreatmentOverride getOverride(String overrideName) {
         return overrides.get(overrideName);
     }
 
-    /**
-     * Activates the experiments, enabling all treatments
-     */
+    /** Activates the experiments, enabling all treatments */
     public Experiment activate() {
         if (active) {
             return this;
@@ -264,9 +258,7 @@ public class Experiment implements Named {
         return this;
     }
 
-    /**
-     * Deactivates the experiment, disabling all treatments
-     */
+    /** Deactivates the experiment, disabling all treatments */
     public Experiment deactivate() {
         if (!active) {
             return this;
@@ -279,6 +271,7 @@ public class Experiment implements Named {
 
     /**
      * Adds a treatment
+     *
      * @param name The name
      */
     public Experiment addTreatment(String name) throws ValidationException {
@@ -288,6 +281,7 @@ public class Experiment implements Named {
 
     /**
      * Adds a treatment
+     *
      * @param name The name
      * @param description The description
      */
@@ -296,9 +290,7 @@ public class Experiment implements Named {
         return this;
     }
 
-    /**
-     * Removes all treatments
-     */
+    /** Removes all treatments */
     public Experiment clearTreatments() {
         final List<Treatment> toRemove = Lists.newArrayList(treatments.values());
         for (final Treatment treatment : toRemove) {
@@ -308,9 +300,7 @@ public class Experiment implements Named {
         return this;
     }
 
-    /**
-     * Removes all overrides
-     */
+    /** Removes all overrides */
     public Experiment clearOverrides() {
         overrides.clear();
         return this;
@@ -318,13 +308,17 @@ public class Experiment implements Named {
 
     /**
      * Add a treatment override for an identity
+     *
      * @param treatmentName The treatment an identity should receive
      * @param overrideName The name of the override
-     * @param filter A filter expression that describes which attributes this override should apply for
+     * @param filter A filter expression that describes which attributes this override should apply
+     *     for
      */
-    public Experiment addOverride(String overrideName, String treatmentName, String filter) throws ValidationException {
+    public Experiment addOverride(String overrideName, String treatmentName, String filter)
+            throws ValidationException {
         final FilterExpression filterExp = FilterExpression.of(filter);
-        final TreatmentOverride override = new TreatmentOverride(overrideName, filterExp, treatment(treatmentName));
+        final TreatmentOverride override =
+                new TreatmentOverride(overrideName, filterExp, treatment(treatmentName));
         overrides.put(overrideName, override);
 
         return this;
@@ -332,6 +326,7 @@ public class Experiment implements Named {
 
     /**
      * Remove an override
+     *
      * @param overrideName The name of the override to remove
      */
     public Experiment removeOverride(String overrideName) {
@@ -341,6 +336,7 @@ public class Experiment implements Named {
 
     /**
      * Removes all overrides for a given treatment
+     *
      * @param treatmentName The treatment to remove overrides for
      */
     public Experiment removeOverrides(String treatmentName) {
@@ -363,6 +359,7 @@ public class Experiment implements Named {
 
     /**
      * Removes a treatment
+     *
      * @param name The treatment
      */
     public Experiment removeTreatment(String name) {
@@ -384,9 +381,7 @@ public class Experiment implements Named {
         return treatment;
     }
 
-    /**
-     * Saves the experiment and all changes made to it
-     */
+    /** Saves the experiment and all changes made to it */
     public Experiment save() {
         if (created == null) {
             created = DateTime.now(DateTimeZone.UTC);
@@ -399,15 +394,14 @@ public class Experiment implements Named {
         return this;
     }
 
-    /**
-     * Deletes the experiment and all things associated with it
-     */
+    /** Deletes the experiment and all things associated with it */
     public void delete() {
         owner.delete(name);
     }
 
     /**
      * Allocates bins to a treatment
+     *
      * @param treatmentName The treatment
      * @param size The number of bins
      */
@@ -419,6 +413,7 @@ public class Experiment implements Named {
 
     /**
      * De-allocates bins from a treatment
+     *
      * @param treatmentName The treatment
      * @param size The number of bins
      */
@@ -429,34 +424,34 @@ public class Experiment implements Named {
 
     /**
      * Reallocates bins from one treatment to another
+     *
      * @param sourceTreatmentName The source treatment
      * @param destinationTreatmentName The destination treatment
      * @param size The number of bins
      */
-    public Experiment reallocate(String sourceTreatmentName, String destinationTreatmentName, int size) {
+    public Experiment reallocate(
+            String sourceTreatmentName, String destinationTreatmentName, int size) {
         allocations.reallocate(
-            treatment(sourceTreatmentName),
-            treatment(destinationTreatmentName),
-            size
-        );
+                treatment(sourceTreatmentName), treatment(destinationTreatmentName), size);
 
         return this;
     }
 
-    /**
-     * Removes all allocations
-     */
+    /** Removes all allocations */
     public Experiment deallocateAll() {
         allocations.clear();
         return this;
     }
 
     private int identityToBin(Identity identity, AttributesMap attributes) {
-        return (int) (FastMath.abs(identity.computeHash(seed, hashAttributes ,attributes)) % Allocations.NUM_BINS);
+        return (int)
+                (FastMath.abs(identity.computeHash(seed, hashAttributes, attributes))
+                        % Allocations.NUM_BINS);
     }
 
     /**
      * Returns treatment for an identity
+     *
      * @param identity The identity
      * @return the treatment assigned to given identity
      */
@@ -476,15 +471,12 @@ public class Experiment implements Named {
         }
 
         final Experiment other = (Experiment) obj;
-        return
-            Objects.equal(name, other.name);
+        return Objects.equal(name, other.name);
     }
 
     @Override
     public String toString() {
-        return
-            MoreObjects
-                .toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("name", name)
                 .add("description", description)
                 .add("filter", filter)
@@ -510,9 +502,7 @@ public class Experiment implements Named {
         }
     }
 
-    /**
-     * Builder for building Experiment inside store
-     */
+    /** Builder for building Experiment inside store */
     public static class Builder {
         private final Experiments owner;
         private final String name;
@@ -522,7 +512,7 @@ public class Experiment implements Named {
         private Set<String> hashAttributes;
         private boolean active;
         private DateTime created = DateTime.now(DateTimeZone.UTC);
-        private DateTime modified  = DateTime.now(DateTimeZone.UTC);
+        private DateTime modified = DateTime.now(DateTimeZone.UTC);
         private DateTime activated;
         private DateTime deactivated;
         private final Map<String, Treatment> treatments;
@@ -547,7 +537,7 @@ public class Experiment implements Named {
             return this;
         }
 
-        public Builder hashAttributes(String ... hashAttributes) {
+        public Builder hashAttributes(String... hashAttributes) {
             this.hashAttributes = Sets.newLinkedHashSet(Arrays.asList(hashAttributes));
             return this;
         }
@@ -589,7 +579,8 @@ public class Experiment implements Named {
 
         private Treatment getTreatment(String name) {
             final Treatment treatment = treatments.get(name);
-            Preconditions.checkArgument(treatment != null, "treatment with name %s must be defined first", name);
+            Preconditions.checkArgument(
+                    treatment != null, "treatment with name %s must be defined first", name);
             return treatment;
         }
 
@@ -598,8 +589,11 @@ public class Experiment implements Named {
             return this;
         }
 
-        public Builder addOverride(String name, String filter, String treatmentName) throws ValidationException {
-            overrides.add(new TreatmentOverride(name, FilterExpression.of(filter), getTreatment(treatmentName)));
+        public Builder addOverride(String name, String filter, String treatmentName)
+                throws ValidationException {
+            overrides.add(
+                    new TreatmentOverride(
+                            name, FilterExpression.of(filter), getTreatment(treatmentName)));
             return this;
         }
 
@@ -610,21 +604,20 @@ public class Experiment implements Named {
 
         public Experiment build() {
             return new Experiment(
-                owner,
-                name,
-                seed,
-                description,
-                filter,
-                hashAttributes,
-                active,
-                created,
-                modified,
-                activated,
-                deactivated,
-                treatments,
-                overrides,
-                allocations
-            );
+                    owner,
+                    name,
+                    seed,
+                    description,
+                    filter,
+                    hashAttributes,
+                    active,
+                    created,
+                    modified,
+                    activated,
+                    deactivated,
+                    treatments,
+                    overrides,
+                    allocations);
         }
     }
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/models/Named.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/models/Named.java
@@ -11,12 +11,8 @@ public interface Named {
     default void validateName() {
         if (getName() == null || !NAME_PATTERN.matcher(getName()).matches()) {
             throw new ValidationException(
-                String.format(
-                    "Invalid name %s, must match %s",
-                    getName(),
-                    NAME_PATTERN.pattern()
-                )
-            );
+                    String.format(
+                            "Invalid name %s, must match %s", getName(), NAME_PATTERN.pattern()));
         }
     }
 }

--- a/alchemy-core/src/main/java/io/rtr/alchemy/models/Treatment.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/models/Treatment.java
@@ -3,13 +3,7 @@ package io.rtr.alchemy.models;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-
-/**
- * Represents a possible user experience in an experiment
- */
-
-
-
+/** Represents a possible user experience in an experiment */
 public class Treatment implements Named {
     private final String name;
     private String description;
@@ -47,15 +41,12 @@ public class Treatment implements Named {
         }
 
         final Treatment other = (Treatment) obj;
-        return
-            Objects.equal(name, other.name);
+        return Objects.equal(name, other.name);
     }
 
     @Override
     public String toString() {
-        return
-            MoreObjects
-                .toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("name", name)
                 .add("description", description)
                 .toString();

--- a/alchemy-core/src/main/java/io/rtr/alchemy/models/TreatmentOverride.java
+++ b/alchemy-core/src/main/java/io/rtr/alchemy/models/TreatmentOverride.java
@@ -4,9 +4,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.rtr.alchemy.filtering.FilterExpression;
 
-/**
- * Represents a treatment override assigned to a specific hash value
- */
+/** Represents a treatment override assigned to a specific hash value */
 public class TreatmentOverride implements Named {
     private final String name;
     private final FilterExpression filter;
@@ -43,16 +41,12 @@ public class TreatmentOverride implements Named {
 
         final TreatmentOverride other = (TreatmentOverride) obj;
 
-        return
-            Objects.equal(name, other.name) &&
-            Objects.equal(treatment, other.treatment);
+        return Objects.equal(name, other.name) && Objects.equal(treatment, other.treatment);
     }
 
     @Override
     public String toString() {
-        return
-            MoreObjects
-                .toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("name", name)
                 .add("filter", filter)
                 .add("treatment", treatment)

--- a/alchemy-core/src/test/java/io/rtr/alchemy/caching/BasicCacheStrategyTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/caching/BasicCacheStrategyTest.java
@@ -41,25 +41,18 @@ public class BasicCacheStrategyTest {
         activeExperiment = mock(Experiment.class);
         doReturn("foo").when(activeExperiment).getName();
         doReturn(true).when(activeExperiment).isActive();
-        doReturn(activeExperiment)
-            .when(store)
-            .load(eq("foo"), any(Experiment.Builder.class));
+        doReturn(activeExperiment).when(store).load(eq("foo"), any(Experiment.Builder.class));
 
         inactiveExperiment = mock(Experiment.class);
         doReturn("bar").when(inactiveExperiment).getName();
         doReturn(false).when(inactiveExperiment).isActive();
-        doReturn(inactiveExperiment)
-            .when(store)
-            .load(eq("bar"), any(Experiment.Builder.class));
+        doReturn(inactiveExperiment).when(store).load(eq("bar"), any(Experiment.Builder.class));
 
         doReturn(Lists.newArrayList(activeExperiment, inactiveExperiment))
-            .when(store).find(any(Filter.class), any(Experiment.BuilderFactory.class));
+                .when(store)
+                .find(any(Filter.class), any(Experiment.BuilderFactory.class));
 
-        experiments =
-            Experiments
-                .using(provider)
-                .using(strategy)
-                .build();
+        experiments = Experiments.using(provider).using(strategy).build();
     }
 
     @Test
@@ -84,9 +77,14 @@ public class BasicCacheStrategyTest {
         final Iterable<Experiment> result = experiments.find();
         final Iterator<Experiment> iterator = result.iterator();
 
-        final Set<String> experimentNames = Sets.newHashSet(activeExperiment.getName(), inactiveExperiment.getName());
-        assertTrue("expected valid experiment name", experimentNames.remove(iterator.next().getName()));
-        assertTrue("expected valid experiment name", experimentNames.remove(iterator.next().getName()));
+        final Set<String> experimentNames =
+                Sets.newHashSet(activeExperiment.getName(), inactiveExperiment.getName());
+        assertTrue(
+                "expected valid experiment name",
+                experimentNames.remove(iterator.next().getName()));
+        assertTrue(
+                "expected valid experiment name",
+                experimentNames.remove(iterator.next().getName()));
         verify(cache).update(eq(activeExperiment));
         verify(cache).delete(eq(inactiveExperiment.getName()));
     }

--- a/alchemy-core/src/test/java/io/rtr/alchemy/caching/CacheStrategyIterableTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/caching/CacheStrategyIterableTest.java
@@ -25,7 +25,8 @@ public class CacheStrategyIterableTest {
 
         experiment = mock(Experiment.class);
         final List<Experiment> experiments = Lists.newArrayList(experiment);
-        final CacheStrategyIterable iterable = new CacheStrategyIterable(experiments, context, strategy);
+        final CacheStrategyIterable iterable =
+                new CacheStrategyIterable(experiments, context, strategy);
         iterator = iterable.iterator();
     }
 

--- a/alchemy-core/src/test/java/io/rtr/alchemy/caching/CacheStrategyTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/caching/CacheStrategyTest.java
@@ -49,25 +49,18 @@ public class CacheStrategyTest {
         experiment1 = mock(Experiment.class);
         doReturn("foo").when(experiment1).getName();
         doReturn(FilterExpression.alwaysTrue()).when(experiment1).getFilter();
-        doReturn(experiment1)
-            .when(store)
-            .load(eq("foo"), any(Experiment.Builder.class));
+        doReturn(experiment1).when(store).load(eq("foo"), any(Experiment.Builder.class));
 
         experiment2 = mock(Experiment.class);
         doReturn("bar").when(experiment2).getName();
         doReturn(FilterExpression.alwaysTrue()).when(experiment2).getFilter();
-        doReturn(experiment2)
-            .when(store)
-            .load(eq("bar"), any(Experiment.Builder.class));
+        doReturn(experiment2).when(store).load(eq("bar"), any(Experiment.Builder.class));
 
         doReturn(Lists.newArrayList(experiment1, experiment2))
-            .when(store).find(any(Filter.class), any(Experiment.BuilderFactory.class));
+                .when(store)
+                .find(any(Filter.class), any(Experiment.BuilderFactory.class));
 
-        experiments =
-            Experiments
-                .using(provider)
-                .using(strategy)
-                .build();
+        experiments = Experiments.using(provider).using(strategy).build();
     }
 
     @Test
@@ -81,13 +74,18 @@ public class CacheStrategyTest {
         reset(strategy);
         final Iterable<Experiment> result = experiments.find();
         final Iterator<Experiment> iterator = result.iterator();
-        final Set<String> experimentNames = Sets.newHashSet(experiment1.getName(), experiment2.getName());
+        final Set<String> experimentNames =
+                Sets.newHashSet(experiment1.getName(), experiment2.getName());
 
         // no interactions until we actually iterate over results
         verifyZeroInteractions(strategy);
 
-        assertTrue("expected valid experiment name", experimentNames.remove(iterator.next().getName()));
-        assertTrue("expected valid experiment name", experimentNames.remove(iterator.next().getName()));
+        assertTrue(
+                "expected valid experiment name",
+                experimentNames.remove(iterator.next().getName()));
+        assertTrue(
+                "expected valid experiment name",
+                experimentNames.remove(iterator.next().getName()));
         verify(strategy, times(2)).onLoad(any(Experiment.class), any(CachingContext.class));
 
         assertFalse("should have no more results", iterator.hasNext());

--- a/alchemy-core/src/test/java/io/rtr/alchemy/db/FilterTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/db/FilterTest.java
@@ -7,9 +7,6 @@ import org.junit.Test;
 public class FilterTest {
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(Filter.class)
-            .suppress(Warning.STRICT_INHERITANCE)
-            .verify();
+        EqualsVerifier.forClass(Filter.class).suppress(Warning.STRICT_INHERITANCE).verify();
     }
 }

--- a/alchemy-core/src/test/java/io/rtr/alchemy/db/OrderingTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/db/OrderingTest.java
@@ -16,25 +16,21 @@ public class OrderingTest {
 
         // single field expression
         assertEquals(
-            ImmutableMap.of(Ordering.Field.NAME, Ordering.Direction.ASCENDING),
-            Ordering.parse("name").getFields()
-        );
+                ImmutableMap.of(Ordering.Field.NAME, Ordering.Direction.ASCENDING),
+                Ordering.parse("name").getFields());
 
         // single descending field expression
         assertEquals(
-            ImmutableMap.of(Ordering.Field.NAME, Ordering.Direction.DESCENDING),
-            Ordering.parse("-name").getFields()
-        );
+                ImmutableMap.of(Ordering.Field.NAME, Ordering.Direction.DESCENDING),
+                Ordering.parse("-name").getFields());
 
         // multiple fields
         assertEquals(
-            ImmutableMap.of(
-                Ordering.Field.ACTIVE, Ordering.Direction.ASCENDING,
-                Ordering.Field.NAME, Ordering.Direction.DESCENDING,
-                Ordering.Field.CREATED, Ordering.Direction.ASCENDING
-            ),
-            Ordering.parse("active,-name,created").getFields()
-        );
+                ImmutableMap.of(
+                        Ordering.Field.ACTIVE, Ordering.Direction.ASCENDING,
+                        Ordering.Field.NAME, Ordering.Direction.DESCENDING,
+                        Ordering.Field.CREATED, Ordering.Direction.ASCENDING),
+                Ordering.parse("active,-name,created").getFields());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -45,37 +41,32 @@ public class OrderingTest {
     @Test
     public void testBuilder() {
         // empty expression
-        assertEquals(
-            Ordering.empty().getFields(),
-            Ordering.newBuilder().build().getFields()
-        );
+        assertEquals(Ordering.empty().getFields(), Ordering.newBuilder().build().getFields());
 
         // single field expression
         assertEquals(
-            ImmutableMap.of(Ordering.Field.NAME, Ordering.Direction.ASCENDING),
-            Ordering.newBuilder().orderBy(Ordering.Field.NAME).build().getFields()
-        );
+                ImmutableMap.of(Ordering.Field.NAME, Ordering.Direction.ASCENDING),
+                Ordering.newBuilder().orderBy(Ordering.Field.NAME).build().getFields());
 
         // single descending field expression
         assertEquals(
-            ImmutableMap.of(Ordering.Field.NAME, Ordering.Direction.DESCENDING),
-            Ordering.newBuilder().orderBy(Ordering.Field.NAME, Ordering.Direction.DESCENDING).build().getFields()
-        );
+                ImmutableMap.of(Ordering.Field.NAME, Ordering.Direction.DESCENDING),
+                Ordering.newBuilder()
+                        .orderBy(Ordering.Field.NAME, Ordering.Direction.DESCENDING)
+                        .build()
+                        .getFields());
 
         // multiple fields
         assertEquals(
-            ImmutableMap.of(
-                Ordering.Field.ACTIVE, Ordering.Direction.ASCENDING,
-                Ordering.Field.NAME, Ordering.Direction.DESCENDING,
-                Ordering.Field.CREATED, Ordering.Direction.ASCENDING
-            ),
-            Ordering
-                .newBuilder()
-                .orderBy(Ordering.Field.ACTIVE, Ordering.Direction.ASCENDING)
-                .orderBy(Ordering.Field.NAME, Ordering.Direction.DESCENDING)
-                .orderBy(Ordering.Field.CREATED)
-                .build()
-                .getFields()
-        );
+                ImmutableMap.of(
+                        Ordering.Field.ACTIVE, Ordering.Direction.ASCENDING,
+                        Ordering.Field.NAME, Ordering.Direction.DESCENDING,
+                        Ordering.Field.CREATED, Ordering.Direction.ASCENDING),
+                Ordering.newBuilder()
+                        .orderBy(Ordering.Field.ACTIVE, Ordering.Direction.ASCENDING)
+                        .orderBy(Ordering.Field.NAME, Ordering.Direction.DESCENDING)
+                        .orderBy(Ordering.Field.CREATED)
+                        .build()
+                        .getFields());
     }
 }

--- a/alchemy-core/src/test/java/io/rtr/alchemy/filtering/FilterExpressionTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/filtering/FilterExpressionTest.java
@@ -17,11 +17,19 @@ public class FilterExpressionTest {
     }
 
     private void assertEval(String expression, boolean expected) {
-        assertEquals(String.format("expected '%s' to be %s", expression, expected), expected, eval(expression));
+        assertEquals(
+                String.format("expected '%s' to be %s", expression, expected),
+                expected,
+                eval(expression));
     }
 
-    private void assertComparison(String comparison, String leftValue, String rightValue,
-                                  boolean expectedLeftRight, boolean expectedRightLeft, boolean expectedSame) {
+    private void assertComparison(
+            String comparison,
+            String leftValue,
+            String rightValue,
+            boolean expectedLeftRight,
+            boolean expectedRightLeft,
+            boolean expectedSame) {
         assertEval(String.format("%s%s%s", leftValue, comparison, rightValue), expectedLeftRight);
         assertEval(String.format("%s%s%s", rightValue, comparison, leftValue), expectedRightLeft);
         assertEval(String.format("%s%s%s", leftValue, comparison, leftValue), expectedSame);
@@ -30,17 +38,17 @@ public class FilterExpressionTest {
 
     @Before
     public void setUp() {
-        attributes = AttributesMap
-            .newBuilder()
-            .put("foo", true)
-            .put("not_foo", false)
-            .put("one", 1)
-            .put("zero", 0)
-            .put("meaning_of_life", 42)
-            .put("apple", "apple")
-            .put("baz", "baz")
-            .put("empty", "")
-            .build();
+        attributes =
+                AttributesMap.newBuilder()
+                        .put("foo", true)
+                        .put("not_foo", false)
+                        .put("one", 1)
+                        .put("zero", 0)
+                        .put("meaning_of_life", 42)
+                        .put("apple", "apple")
+                        .put("baz", "baz")
+                        .put("empty", "")
+                        .build();
     }
 
     @Test
@@ -79,9 +87,13 @@ public class FilterExpressionTest {
         assertEval("does_not_exist", false);
     }
 
-    private void testComparisons(String booleanLhs, String booleanRhs,
-                                 String numberLhs, String numberRhs,
-                                 String stringLhs, String stringRhs) {
+    private void testComparisons(
+            String booleanLhs,
+            String booleanRhs,
+            String numberLhs,
+            String numberRhs,
+            String stringLhs,
+            String stringRhs) {
         // >
         assertComparison(">", booleanLhs, booleanRhs, true, false, false);
         assertComparison(">", numberLhs, numberRhs, true, false, false);
@@ -123,8 +135,7 @@ public class FilterExpressionTest {
         testComparisons(
                 "true", "false",
                 "1", "0",
-                "\"bear\"", "\"apple\""
-        );
+                "\"bear\"", "\"apple\"");
     }
 
     @Test
@@ -132,8 +143,7 @@ public class FilterExpressionTest {
         testComparisons(
                 "true", "not_foo",
                 "1", "zero",
-                "baz", "\"apple\""
-        );
+                "baz", "\"apple\"");
     }
 
     @Test
@@ -141,8 +151,7 @@ public class FilterExpressionTest {
         testComparisons(
                 "foo", "not_foo",
                 "one", "zero",
-                "baz", "apple"
-        );
+                "baz", "apple");
     }
 
     @Test

--- a/alchemy-core/src/test/java/io/rtr/alchemy/identities/AttributesMapTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/identities/AttributesMapTest.java
@@ -14,12 +14,12 @@ public class AttributesMapTest {
 
     @Before
     public void setUp() {
-        map = AttributesMap
-            .newBuilder()
-            .put("true", true)
-            .put("one", 1)
-            .put("string", "string")
-            .build();
+        map =
+                AttributesMap.newBuilder()
+                        .put("true", true)
+                        .put("one", 1)
+                        .put("string", "string")
+                        .build();
     }
 
     @Test
@@ -57,39 +57,49 @@ public class AttributesMapTest {
     private void assertImmutable(String method, Runnable testMethod) {
         try {
             testMethod.run();
-            fail(String.format("method %s should not be allowed on immutable AttributesMap", method));
+            fail(
+                    String.format(
+                            "method %s should not be allowed on immutable AttributesMap", method));
         } catch (UnsupportedOperationException ignored) {
         }
     }
 
     @Test
     public void testImmutable() {
-        assertImmutable("put", new Runnable() {
-            @Override
-            public void run() {
-                map.put("foo", "bar");
-            }
-        });
+        assertImmutable(
+                "put",
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        map.put("foo", "bar");
+                    }
+                });
 
-        assertImmutable("putAll", new Runnable() {
-            @Override
-            public void run() {
-                map.putAll(map);
-            }
-        });
+        assertImmutable(
+                "putAll",
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        map.putAll(map);
+                    }
+                });
 
-        assertImmutable("remove", new Runnable() {
-            @Override
-            public void run() {
-                map.remove("true");
-            }
-        });
+        assertImmutable(
+                "remove",
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        map.remove("true");
+                    }
+                });
 
-        assertImmutable("clear", new Runnable() {
-            @Override
-            public void run() {
-                map.clear();
-            }
-        });
+        assertImmutable(
+                "clear",
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        map.clear();
+                    }
+                });
     }
 }

--- a/alchemy-core/src/test/java/io/rtr/alchemy/identities/IdentityBuilderTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/identities/IdentityBuilderTest.java
@@ -19,23 +19,24 @@ public class IdentityBuilderTest {
     @Test
     public void testHashAll() {
         final Identity identity = mock(Identity.class);
-        doReturn(1L).when(identity).computeHash(anyInt(), Mockito.<Set<String>>any(), any(AttributesMap.class));
+        doReturn(1L)
+                .when(identity)
+                .computeHash(anyInt(), Mockito.<Set<String>>any(), any(AttributesMap.class));
 
         final long hash =
-            IdentityBuilder
-                .seed(0)
-                .putBoolean(true)
-                .putByte((byte) 1)
-                .putBytes(new byte[]{1, 2, 3})
-                .putChar('a')
-                .putDouble(1.0)
-                .putFloat(1.0f)
-                .putInt(1)
-                .putLong(1L)
-                .putShort((short) 1)
-                .putString("foo")
-                .putNull()
-                .hash();
+                IdentityBuilder.seed(0)
+                        .putBoolean(true)
+                        .putByte((byte) 1)
+                        .putBytes(new byte[] {1, 2, 3})
+                        .putChar('a')
+                        .putDouble(1.0)
+                        .putFloat(1.0f)
+                        .putInt(1)
+                        .putLong(1L)
+                        .putShort((short) 1)
+                        .putString("foo")
+                        .putNull()
+                        .hash();
 
         assertEquals(-3880933330945736271L, hash);
     }
@@ -43,20 +44,19 @@ public class IdentityBuilderTest {
     @Test
     public void testHashNulls() {
         final long hash =
-            IdentityBuilder
-                .seed(0)
-                .putBoolean(null)
-                .putByte(null)
-                .putBytes(null)
-                .putChar(null)
-                .putDouble(null)
-                .putFloat(null)
-                .putInt(null)
-                .putLong(null)
-                .putShort(null)
-                .putString(null)
-                .putNull()
-                .hash();
+                IdentityBuilder.seed(0)
+                        .putBoolean(null)
+                        .putByte(null)
+                        .putBytes(null)
+                        .putChar(null)
+                        .putDouble(null)
+                        .putFloat(null)
+                        .putInt(null)
+                        .putLong(null)
+                        .putShort(null)
+                        .putString(null)
+                        .putNull()
+                        .hash();
 
         assertEquals(7075199957211664123L, hash);
 
@@ -69,7 +69,10 @@ public class IdentityBuilderTest {
     public void testHashDifferentSeeds() {
         final long hash1 = IdentityBuilder.seed(1).putBoolean(true).hash();
         final long hash2 = IdentityBuilder.seed(2).putBoolean(true).hash();
-        assertNotEquals("hashes generated with different seeds should be different most of the time", hash1, hash2);
+        assertNotEquals(
+                "hashes generated with different seeds should be different most of the time",
+                hash1,
+                hash2);
     }
 
     @Test
@@ -89,30 +92,31 @@ public class IdentityBuilderTest {
     public void testDistribution() {
         final ChiSquareTest chiSquareTest = new ChiSquareTest();
 
-        for (int numBins=MIN_NUM_BINS; numBins <= MAX_NUM_BINS; numBins++) {
+        for (int numBins = MIN_NUM_BINS; numBins <= MAX_NUM_BINS; numBins++) {
             final double[] expectedFrequencies = new double[numBins];
             final long[] actualFrequencies = new long[numBins];
 
-            for (int i=0; i<numBins; i++) {
+            for (int i = 0; i < numBins; i++) {
                 expectedFrequencies[i] = SAMPLE_SIZE / numBins;
             }
 
             for (int seed = 0; seed < NUMBER_SEEDS; seed++) {
                 for (int sample = 0; sample < SAMPLE_SIZE; sample++) {
-                    final int bin = (int) (Math.abs(IdentityBuilder.seed(seed).putInt(sample).hash()) % numBins);
+                    final int bin =
+                            (int)
+                                    (Math.abs(IdentityBuilder.seed(seed).putInt(sample).hash())
+                                            % numBins);
                     actualFrequencies[bin]++;
                 }
 
-                final double significance = chiSquareTest.chiSquareTest(expectedFrequencies, actualFrequencies);
+                final double significance =
+                        chiSquareTest.chiSquareTest(expectedFrequencies, actualFrequencies);
 
                 assertTrue(
-                    String.format(
-                        "distribution was not uniform, significance was %.4f for %d bins",
-                        significance,
-                        numBins
-                    ),
-                    significance > EXPECTED_SIGNIFICANCE
-                );
+                        String.format(
+                                "distribution was not uniform, significance was %.4f for %d bins",
+                                significance, numBins),
+                        significance > EXPECTED_SIGNIFICANCE);
             }
         }
     }

--- a/alchemy-core/src/test/java/io/rtr/alchemy/identities/IdentityTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/identities/IdentityTest.java
@@ -13,9 +13,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Attributes(
-    value = {"foo", "bar"},
-    identities = { IdentityTest.Other.class }
-)
+        value = {"foo", "bar"},
+        identities = {IdentityTest.Other.class})
 public class IdentityTest extends Identity {
     @Test
     public void testAttributes() {
@@ -31,35 +30,33 @@ public class IdentityTest extends Identity {
     @Test
     public void testComputeHashcodeOrderMatters() {
         final IdentityTest identity = new IdentityTest();
-        final AttributesMap map = AttributesMap.newBuilder().put("foo", "foo").put("bar", "bar").build();
+        final AttributesMap map =
+                AttributesMap.newBuilder().put("foo", "foo").put("bar", "bar").build();
         final Set<String> fooBar = Sets.newLinkedHashSet(Lists.newArrayList("foo", "bar"));
         final Set<String> barFoo = Sets.newLinkedHashSet(Lists.newArrayList("bar", "foo"));
         final int seed = 0;
 
-        assertEquals(identity.computeHash(seed, fooBar, map), identity.computeHash(seed, fooBar, map));
-        assertEquals(identity.computeHash(seed, barFoo, map), identity.computeHash(seed, barFoo, map));
+        assertEquals(
+                identity.computeHash(seed, fooBar, map), identity.computeHash(seed, fooBar, map));
+        assertEquals(
+                identity.computeHash(seed, barFoo, map), identity.computeHash(seed, barFoo, map));
 
-        assertNotEquals(identity.computeHash(seed, fooBar, map), identity.computeHash(seed, barFoo, map));
-        assertNotEquals(identity.computeHash(seed, barFoo, map), identity.computeHash(seed, fooBar, map));
+        assertNotEquals(
+                identity.computeHash(seed, fooBar, map), identity.computeHash(seed, barFoo, map));
+        assertNotEquals(
+                identity.computeHash(seed, barFoo, map), identity.computeHash(seed, fooBar, map));
     }
-
 
     @Override
     public AttributesMap computeAttributes() {
-        return attributes()
-                .put("foo", true)
-                .put("bar", false)
-                .put(new Other())
-                .build();
+        return attributes().put("foo", true).put("bar", false).put(new Other()).build();
     }
 
     @Attributes({"baz"})
     public static class Other extends Identity {
         @Override
         public AttributesMap computeAttributes() {
-            return attributes()
-                    .put("baz", 1)
-                    .build();
+            return attributes().put("baz", 1).build();
         }
     }
 }

--- a/alchemy-core/src/test/java/io/rtr/alchemy/models/AllocationTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/models/AllocationTest.java
@@ -7,9 +7,6 @@ import org.junit.Test;
 public class AllocationTest {
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(Allocation.class)
-            .suppress(Warning.STRICT_INHERITANCE)
-            .verify();
+        EqualsVerifier.forClass(Allocation.class).suppress(Warning.STRICT_INHERITANCE).verify();
     }
 }

--- a/alchemy-core/src/test/java/io/rtr/alchemy/models/AllocationsTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/models/AllocationsTest.java
@@ -14,16 +14,18 @@ import static org.junit.Assert.assertTrue;
 
 public class AllocationsTest {
     private static final Treatment control, withLogin, withoutLogin;
+
     static {
-        // based on https://stackoverflow.com/questions/8367950/cant-define-a-private-static-final-variable-because-it-throws-an-exception
+        // based on
+        // https://stackoverflow.com/questions/8367950/cant-define-a-private-static-final-variable-because-it-throws-an-exception
         Treatment tmp1 = null;
-        Treatment tmp2= null;
-        Treatment tmp3= null;
+        Treatment tmp2 = null;
+        Treatment tmp3 = null;
         try {
             tmp1 = new Treatment("control", "This is the control");
             tmp2 = new Treatment("with_login", "User logged in");
-            tmp3= new Treatment("without_login", "User didn't log in");
-        } catch(ValidationException e) {
+            tmp3 = new Treatment("without_login", "User didn't log in");
+        } catch (ValidationException e) {
             // do nothing
         }
         control = tmp1;
@@ -31,63 +33,81 @@ public class AllocationsTest {
         withoutLogin = tmp3;
     }
 
-
     @Test
     public void testConstructWithEmptyList() {
         final Allocations allocations = new Allocations(Lists.<Allocation>newArrayList());
-        assertEquals("unallocated size should be number of bins", Allocations.NUM_BINS, allocations.getUnallocatedSize());
+        assertEquals(
+                "unallocated size should be number of bins",
+                Allocations.NUM_BINS,
+                allocations.getUnallocatedSize());
         assertEquals("allocation size should be zero", 0, allocations.getSize());
         assertTrue("allocations should be empty", allocations.getAllocations().isEmpty());
 
-        for (int i=0; i < Allocations.NUM_BINS; i++) {
+        for (int i = 0; i < Allocations.NUM_BINS; i++) {
             assertNull("unallocated treatment should return as null", allocations.getTreatment(i));
         }
     }
 
     @Test
     public void testConstructWithUnorderedAllocations() {
-        final List<Allocation> allocationList = Lists.newArrayList(
-            new Allocation(control, 0, 20),
-            new Allocation(withoutLogin, 50, 40),
-            new Allocation(withLogin, 20, 30)
-        );
+        final List<Allocation> allocationList =
+                Lists.newArrayList(
+                        new Allocation(control, 0, 20),
+                        new Allocation(withoutLogin, 50, 40),
+                        new Allocation(withLogin, 20, 30));
 
         final Allocations allocations = new Allocations(allocationList);
 
-        assertEquals("unallocated size should match", Allocations.NUM_BINS - 90, allocations.getUnallocatedSize());
+        assertEquals(
+                "unallocated size should match",
+                Allocations.NUM_BINS - 90,
+                allocations.getUnallocatedSize());
         assertEquals("size should match", 90, allocations.getSize());
 
-        Collections.sort(allocationList, new Comparator<Allocation>() {
-            @Override
-            public int compare(Allocation lhs, Allocation rhs) {
-                return Integer.compare(lhs.getOffset(), rhs.getOffset());
-            }
-        });
-        assertEquals("allocations should match sorted original input", allocationList, allocations.getAllocations());
+        Collections.sort(
+                allocationList,
+                new Comparator<Allocation>() {
+                    @Override
+                    public int compare(Allocation lhs, Allocation rhs) {
+                        return Integer.compare(lhs.getOffset(), rhs.getOffset());
+                    }
+                });
+        assertEquals(
+                "allocations should match sorted original input",
+                allocationList,
+                allocations.getAllocations());
 
-        for (int i=0; i<20; i++) {
-            assertEquals("first set of 20 should be control", allocationList.get(0).getTreatment(), allocations.getTreatment(i));
+        for (int i = 0; i < 20; i++) {
+            assertEquals(
+                    "first set of 20 should be control",
+                    allocationList.get(0).getTreatment(),
+                    allocations.getTreatment(i));
         }
 
-        for (int i=20; i<50; i++) {
-            assertEquals("second set of 30 should be with_login", allocationList.get(1).getTreatment(), allocations.getTreatment(i));
+        for (int i = 20; i < 50; i++) {
+            assertEquals(
+                    "second set of 30 should be with_login",
+                    allocationList.get(1).getTreatment(),
+                    allocations.getTreatment(i));
         }
 
-        for (int i=50; i<90; i++) {
-            assertEquals("third set of 40 should be without_login", allocationList.get(2).getTreatment(), allocations.getTreatment(i));
+        for (int i = 50; i < 90; i++) {
+            assertEquals(
+                    "third set of 40 should be without_login",
+                    allocationList.get(2).getTreatment(),
+                    allocations.getTreatment(i));
         }
 
-        for (int i=90; i<Allocations.NUM_BINS - 90; i++) {
+        for (int i = 90; i < Allocations.NUM_BINS - 90; i++) {
             assertNull("the rest should be unallocated", allocations.getTreatment(i));
         }
     }
 
     @Test(expected = IllegalStateException.class)
     public void testConstructWithOverlappingAllocations() {
-        final List<Allocation> allocationList = Lists.newArrayList(
-            new Allocation(control, 0, 20),
-            new Allocation(withoutLogin, 10, 20)
-        );
+        final List<Allocation> allocationList =
+                Lists.newArrayList(
+                        new Allocation(control, 0, 20), new Allocation(withoutLogin, 10, 20));
 
         new Allocations(allocationList);
     }
@@ -109,14 +129,12 @@ public class AllocationsTest {
         allocations.allocate(withoutLogin, 30);
 
         assertEquals(
-            "should be three contiguous allocations of various sizes",
-            Lists.newArrayList(
-                new Allocation(control, 0, 10),
-                new Allocation(withLogin, 10, 20),
-                new Allocation(withoutLogin, 30, 30)
-            ),
-            allocations.getAllocations()
-        );
+                "should be three contiguous allocations of various sizes",
+                Lists.newArrayList(
+                        new Allocation(control, 0, 10),
+                        new Allocation(withLogin, 10, 20),
+                        new Allocation(withoutLogin, 30, 30)),
+                allocations.getAllocations());
     }
 
     @Test
@@ -132,12 +150,9 @@ public class AllocationsTest {
         allocations.allocate(control, 5);
 
         assertEquals(
-            "both allocations should have been merged into one allocation",
-            Lists.newArrayList(
-                new Allocation(control, 0, 10)
-            ),
-            allocations.getAllocations()
-        );
+                "both allocations should have been merged into one allocation",
+                Lists.newArrayList(new Allocation(control, 0, 10)),
+                allocations.getAllocations());
     }
 
     @Test
@@ -157,15 +172,13 @@ public class AllocationsTest {
         allocations.deallocate(withoutLogin, 15);
 
         assertEquals(
-            "allocations should be smaller and within the same offset range",
-            // deallocations are applied from left to right
-            Lists.newArrayList(
-                new Allocation(control, 5, 5),
-                new Allocation(withLogin, 20, 10),
-                new Allocation(withoutLogin, 45, 15)
-            ),
-            allocations.getAllocations()
-        );
+                "allocations should be smaller and within the same offset range",
+                // deallocations are applied from left to right
+                Lists.newArrayList(
+                        new Allocation(control, 5, 5),
+                        new Allocation(withLogin, 20, 10),
+                        new Allocation(withoutLogin, 45, 15)),
+                allocations.getAllocations());
     }
 
     @Test
@@ -187,13 +200,10 @@ public class AllocationsTest {
         allocations.allocate(control, 5);
 
         assertEquals(
-            "allocation that filled the gap after deallocation should have been merged with adjacent allocation",
-            Lists.newArrayList(
-                new Allocation(control, 0, 15),
-                new Allocation(withLogin, 15, 5)
-            ),
-            allocations.getAllocations()
-        );
+                "allocation that filled the gap after deallocation should have been merged with adjacent allocation",
+                Lists.newArrayList(
+                        new Allocation(control, 0, 15), new Allocation(withLogin, 15, 5)),
+                allocations.getAllocations());
     }
 
     @Test
@@ -213,15 +223,13 @@ public class AllocationsTest {
         allocations.allocate(control, 4);
 
         assertEquals(
-            "new allocation should have filled the gaps and merged with first allocation",
-            Lists.newArrayList(
-                new Allocation(control, 0, 4),
-                new Allocation(withLogin, 4, 2),
-                new Allocation(control, 6, 2),
-                new Allocation(withoutLogin, 8, 2)
-                ),
-            allocations.getAllocations()
-        );
+                "new allocation should have filled the gaps and merged with first allocation",
+                Lists.newArrayList(
+                        new Allocation(control, 0, 4),
+                        new Allocation(withLogin, 4, 2),
+                        new Allocation(control, 6, 2),
+                        new Allocation(withoutLogin, 8, 2)),
+                allocations.getAllocations());
     }
 
     @Test
@@ -238,13 +246,9 @@ public class AllocationsTest {
         allocations.reallocate(withLogin, control, 3);
 
         assertEquals(
-            "reallocation should have partly replaced second allocation and merged with first allocation",
-            Lists.newArrayList(
-                new Allocation(control, 0, 8),
-                new Allocation(withLogin, 8, 2)
-            ),
-            allocations.getAllocations()
-        );
+                "reallocation should have partly replaced second allocation and merged with first allocation",
+                Lists.newArrayList(new Allocation(control, 0, 8), new Allocation(withLogin, 8, 2)),
+                allocations.getAllocations());
     }
 
     @Test
@@ -264,14 +268,12 @@ public class AllocationsTest {
         allocations.reallocate(withLogin, control, 3);
 
         assertEquals(
-            "reallocation should have replaced all occurrences of second allocation, except one bin",
-            Lists.newArrayList(
-                new Allocation(control, 0, 7),
-                new Allocation(withLogin, 7, 1),
-                new Allocation(control, 8, 2)
-            ),
-            allocations.getAllocations()
-        );
+                "reallocation should have replaced all occurrences of second allocation, except one bin",
+                Lists.newArrayList(
+                        new Allocation(control, 0, 7),
+                        new Allocation(withLogin, 7, 1),
+                        new Allocation(control, 8, 2)),
+                allocations.getAllocations());
     }
 
     @Test
@@ -286,10 +288,9 @@ public class AllocationsTest {
             t2 = null;
         }
 
-        final  Allocations allocations = new Allocations(Lists.newArrayList(
-            new Allocation(t1, 0, 5),
-            new Allocation(t2, 5, 5)
-        ));
+        final Allocations allocations =
+                new Allocations(
+                        Lists.newArrayList(new Allocation(t1, 0, 5), new Allocation(t2, 5, 5)));
 
         assertEquals(2, allocations.getAllocations().size());
         assertEquals(10, allocations.getSize());

--- a/alchemy-core/src/test/java/io/rtr/alchemy/models/ExperimentTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/models/ExperimentTest.java
@@ -36,20 +36,21 @@ public class ExperimentTest {
 
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(Experiment.class)
-            .withPrefabValues(Experiments.class, mock(Experiments.class), mock(Experiments.class))
-            .withPrefabValues(FilterExpression.class, mock(FilterExpression.class), mock(FilterExpression.class))
-            .suppress(Warning.STRICT_INHERITANCE)
-            .verify();
+        EqualsVerifier.forClass(Experiment.class)
+                .withPrefabValues(
+                        Experiments.class, mock(Experiments.class), mock(Experiments.class))
+                .withPrefabValues(
+                        FilterExpression.class,
+                        mock(FilterExpression.class),
+                        mock(FilterExpression.class))
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
     }
 
     @Test
-    public void testAddTreatment()  throws ValidationException {
+    public void testAddTreatment() throws ValidationException {
         final Treatment treatment = new Treatment("bar");
-        final Experiment experiment =
-            new Experiment(null, "foo")
-                .addTreatment("bar");
+        final Experiment experiment = new Experiment(null, "foo").addTreatment("bar");
 
         assertEquals(treatment, experiment.getTreatments().iterator().next());
     }
@@ -57,11 +58,12 @@ public class ExperimentTest {
     @Test
     public void testAddOverride() throws ValidationException {
         final Treatment treatment = new Treatment("bar");
-        final TreatmentOverride override = new TreatmentOverride("override", FilterExpression.alwaysTrue(), treatment);
+        final TreatmentOverride override =
+                new TreatmentOverride("override", FilterExpression.alwaysTrue(), treatment);
         final Experiment experiment =
-            new Experiment(null, "foo")
-                .addTreatment("bar")
-                .addOverride("override", "bar", "true");
+                new Experiment(null, "foo")
+                        .addTreatment("bar")
+                        .addOverride("override", "bar", "true");
 
         assertEquals(treatment, experiment.getTreatments().get(0));
         assertEquals(override, experiment.getOverrides().get(0));
@@ -70,23 +72,24 @@ public class ExperimentTest {
     @Test
     public void testGetOverride() throws ValidationException {
         final Treatment treatment = new Treatment("bar");
-        final TreatmentOverride override = new TreatmentOverride("override", FilterExpression.alwaysTrue(), treatment);
+        final TreatmentOverride override =
+                new TreatmentOverride("override", FilterExpression.alwaysTrue(), treatment);
         final Experiment experiment =
-            new Experiment(null, "foo")
-                .addTreatment("bar")
-                .addOverride("override", "bar", "true");
+                new Experiment(null, "foo")
+                        .addTreatment("bar")
+                        .addOverride("override", "bar", "true");
 
         assertEquals(treatment, experiment.getTreatments().get(0));
         assertEquals(override, experiment.getOverride(override.getName()));
     }
 
     @Test
-    public void testClearTreatments()  throws ValidationException {
+    public void testClearTreatments() throws ValidationException {
         final Experiment experiment =
-            new Experiment(null, "foo")
-                .addTreatment("bar")
-                .allocate("bar", 10)
-                .addOverride("override", "bar", "true");
+                new Experiment(null, "foo")
+                        .addTreatment("bar")
+                        .allocate("bar", 10)
+                        .addOverride("override", "bar", "true");
 
         assertEquals(1, experiment.getTreatments().size());
         assertEquals(1, experiment.getAllocations().size());
@@ -100,11 +103,11 @@ public class ExperimentTest {
     }
 
     @Test
-    public void testClearOverrides() throws ValidationException  {
+    public void testClearOverrides() throws ValidationException {
         final Experiment experiment =
-            new Experiment(null, "foo")
-                .addTreatment("bar")
-                .addOverride("override", "bar", "true");
+                new Experiment(null, "foo")
+                        .addTreatment("bar")
+                        .addOverride("override", "bar", "true");
 
         assertEquals(1, experiment.getTreatments().size());
         assertEquals(1, experiment.getOverrides().size());
@@ -116,11 +119,9 @@ public class ExperimentTest {
     }
 
     @Test
-    public void testDeallocateAll()  throws ValidationException {
+    public void testDeallocateAll() throws ValidationException {
         final Experiment experiment =
-            new Experiment(null, "foo")
-                .addTreatment("bar")
-                .allocate("bar", 10);
+                new Experiment(null, "foo").addTreatment("bar").allocate("bar", 10);
 
         assertEquals(1, experiment.getTreatments().size());
         assertEquals(1, experiment.getAllocations().size());
@@ -132,21 +133,23 @@ public class ExperimentTest {
     }
 
     @Test
-    public void testRemoveTreatment() throws ValidationException  {
-        doReturn(0L).when(identity).computeHash(anyInt(), Mockito.<Set<String>>any(), any(AttributesMap.class));
+    public void testRemoveTreatment() throws ValidationException {
+        doReturn(0L)
+                .when(identity)
+                .computeHash(anyInt(), Mockito.<Set<String>>any(), any(AttributesMap.class));
 
         final Experiment experiment =
-            new Experiment(null, "foo")
-                .addTreatment("control")
-                .addTreatment("cake")
-                .addTreatment("pie")
-                .allocate("control", 10)
-                .allocate("cake", 10)
-                .allocate("pie", 10)
-                .allocate("control", 10)
-                .allocate("cake", 10)
-                .allocate("pie", 10)
-                .addOverride("control_override", "control", "true");
+                new Experiment(null, "foo")
+                        .addTreatment("control")
+                        .addTreatment("cake")
+                        .addTreatment("pie")
+                        .allocate("control", 10)
+                        .allocate("cake", 10)
+                        .allocate("pie", 10)
+                        .allocate("control", 10)
+                        .allocate("cake", 10)
+                        .allocate("pie", 10)
+                        .addOverride("control_override", "control", "true");
 
         List<Treatment> treatments = Lists.newArrayList(experiment.getTreatments());
         assertEquals("should contain expected number of treatments", 3, treatments.size());
@@ -174,7 +177,8 @@ public class ExperimentTest {
         assertEquals("should contain fewer treatments", 1, treatments.size());
 
         allocations = Lists.newArrayList(experiment.getAllocations());
-        // (it's 1 allocation rather than 2, because the remaining 'cake' allocations merge into one)
+        // (it's 1 allocation rather than 2, because the remaining 'cake' allocations merge into
+        // one)
         assertEquals("should contain fewer allocations", 1, allocations.size());
 
         overrides = Lists.newArrayList(experiment.getOverrides());
@@ -182,44 +186,40 @@ public class ExperimentTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testUnmodifiableAllocations()  throws ValidationException {
-        final  Experiment experiment =
-            new Experiment(null, "experiment")
-                .addTreatment("foo")
-                .allocate("foo", 10);
+    public void testUnmodifiableAllocations() throws ValidationException {
+        final Experiment experiment =
+                new Experiment(null, "experiment").addTreatment("foo").allocate("foo", 10);
 
         experiment.getAllocations().add(mock(Allocation.class));
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testUnmodifiableTreatments()  throws ValidationException {
-        final  Experiment experiment =
-            new Experiment(null, "experiment")
-                .addTreatment("foo");
+    public void testUnmodifiableTreatments() throws ValidationException {
+        final Experiment experiment = new Experiment(null, "experiment").addTreatment("foo");
 
         experiment.getTreatments().add(mock(Treatment.class));
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testUnmodifiableOverrides()  throws ValidationException {
-        final  Experiment experiment =
-            new Experiment(null, "experiment")
-                .addTreatment("foo")
-                .addOverride("override", "foo", "true");
+    public void testUnmodifiableOverrides() throws ValidationException {
+        final Experiment experiment =
+                new Experiment(null, "experiment")
+                        .addTreatment("foo")
+                        .addOverride("override", "foo", "true");
 
         experiment.getOverrides().add(mock(TreatmentOverride.class));
     }
 
     @Test
-    public void testCopyOf()  throws ValidationException {
+    public void testCopyOf() throws ValidationException {
         assertNull(Experiment.copyOf(null));
 
         final Experiment original =
-            new Experiment(null, "experiment")
-                .activate()
-                .addTreatment("foo")
-                .addOverride("override", "foo", "true")
-                .allocate("foo", 10);
+                new Experiment(null, "experiment")
+                        .activate()
+                        .addTreatment("foo")
+                        .addOverride("override", "foo", "true")
+                        .allocate("foo", 10);
 
         final Experiment copy = Experiment.copyOf(original);
 
@@ -232,13 +232,13 @@ public class ExperimentTest {
     }
 
     @Test
-    public void testSave()  throws ValidationException {
+    public void testSave() throws ValidationException {
         final Experiment experiment = new Experiment(experiments, "foo").save();
         verify(experiments).save(eq(experiment));
     }
 
     @Test
-    public void testDelete()  throws ValidationException {
+    public void testDelete() throws ValidationException {
         final Experiment experiment = new Experiment(experiments, "foo");
         experiment.delete();
         verify(experiments).delete(eq(experiment.getName()));

--- a/alchemy-core/src/test/java/io/rtr/alchemy/models/ExperimentsTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/models/ExperimentsTest.java
@@ -37,7 +37,7 @@ public class ExperimentsTest {
     private static class MyIdentity extends Identity {
         private final Set<String> attributes;
 
-        public MyIdentity(String ... attributes) {
+        public MyIdentity(String... attributes) {
             this.attributes = Sets.newHashSet(attributes);
         }
 
@@ -60,11 +60,7 @@ public class ExperimentsTest {
         cache = mock(ExperimentsCache.class);
         doReturn(store).when(provider).getStore();
         doReturn(cache).when(provider).getCache();
-        experiments =
-            Experiments
-                .using(provider)
-                .using(mock(CacheStrategy.class))
-                .build();
+        experiments = Experiments.using(provider).using(mock(CacheStrategy.class)).build();
 
         // suppress initial invalidateAll() call
         reset(cache);
@@ -76,9 +72,7 @@ public class ExperimentsTest {
         final Experiment experiment = mock(Experiment.class);
         doReturn(AttributesMap.empty()).when(identity).computeAttributes();
         doReturn(FilterExpression.alwaysTrue()).when(experiment).getFilter();
-        doReturn(ImmutableMap.of("foo", experiment))
-            .when(cache)
-            .getActiveExperiments();
+        doReturn(ImmutableMap.of("foo", experiment)).when(cache).getActiveExperiments();
         experiments.getActiveTreatment("foo", identity);
         verifyZeroInteractions(store);
         verify(cache).getActiveExperiments();
@@ -91,29 +85,29 @@ public class ExperimentsTest {
         final MyIdentity identity3 = new MyIdentity("foo");
 
         final Experiment exp1 =
-            experiments
-                .create("exp1")
-                .addTreatment("control")
-                .allocate("control", 100)
-                .setFilter(FilterExpression.of("baz"))
-                .activate()
-                .save();
+                experiments
+                        .create("exp1")
+                        .addTreatment("control")
+                        .allocate("control", 100)
+                        .setFilter(FilterExpression.of("baz"))
+                        .activate()
+                        .save();
 
         final Experiment exp2 =
-            experiments
-                .create("exp2")
-                .addTreatment("control")
-                .allocate("control", 100)
-                .setFilter(FilterExpression.of("bar"))
-                .activate()
-                .save();
+                experiments
+                        .create("exp2")
+                        .addTreatment("control")
+                        .allocate("control", 100)
+                        .setFilter(FilterExpression.of("bar"))
+                        .activate()
+                        .save();
 
         doReturn(
-            ImmutableMap.of(
-                "exp1", exp1,
-                "exp2", exp2
-            )
-        ).when(cache).getActiveExperiments();
+                        ImmutableMap.of(
+                                "exp1", exp1,
+                                "exp2", exp2))
+                .when(cache)
+                .getActiveExperiments();
 
         // baz was not specified in @Attributes
         assertNull(experiments.getActiveTreatment("exp1", identity1));
@@ -131,19 +125,15 @@ public class ExperimentsTest {
         doReturn(AttributesMap.empty()).when(identity).computeAttributes();
 
         final Experiment exp =
-            experiments
-                .create("exp")
-                .addTreatment("control")
-                .allocate("control", 100)
-                .setFilter(FilterExpression.of("baz"))
-                .activate()
-                .save();
+                experiments
+                        .create("exp")
+                        .addTreatment("control")
+                        .allocate("control", 100)
+                        .setFilter(FilterExpression.of("baz"))
+                        .activate()
+                        .save();
 
-        doReturn(
-            ImmutableMap.of(
-                "exp", exp
-            )
-        ).when(cache).getActiveExperiments();
+        doReturn(ImmutableMap.of("exp", exp)).when(cache).getActiveExperiments();
 
         // identity does not have @Attributes
         assertNull(experiments.getActiveTreatment("exp", identity));
@@ -155,9 +145,7 @@ public class ExperimentsTest {
         final Identity identity = mock(Identity.class);
         doReturn(FilterExpression.alwaysTrue()).when(experiment).getFilter();
         doReturn(AttributesMap.empty()).when(identity).computeAttributes();
-        doReturn(ImmutableMap.of("foo", experiment))
-            .when(cache)
-            .getActiveExperiments();
+        doReturn(ImmutableMap.of("foo", experiment)).when(cache).getActiveExperiments();
         experiments.getActiveTreatments(identity);
         verifyZeroInteractions(store);
         verify(cache).getActiveExperiments();

--- a/alchemy-core/src/test/java/io/rtr/alchemy/models/TreatmentOverrideTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/models/TreatmentOverrideTest.java
@@ -10,26 +10,31 @@ import static org.mockito.Mockito.mock;
 
 public class TreatmentOverrideTest {
     final Treatment treatment = new Treatment("treatment");
+
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(TreatmentOverride.class)
-            .suppress(Warning.STRICT_INHERITANCE)
-            .withPrefabValues(FilterExpression.class, mock(FilterExpression.class), mock(FilterExpression.class))
-            .verify();
+        EqualsVerifier.forClass(TreatmentOverride.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .withPrefabValues(
+                        FilterExpression.class,
+                        mock(FilterExpression.class),
+                        mock(FilterExpression.class))
+                .verify();
     }
-
 
     @Test
     public void testValidName() throws ValidationException {
         String name = "a_valid_name";
-        final TreatmentOverride override = new TreatmentOverride(name, mock(FilterExpression.class),treatment);
+        final TreatmentOverride override =
+                new TreatmentOverride(name, mock(FilterExpression.class), treatment);
         assertEquals(override.getName(), name);
     }
 
     @Test(expected = ValidationException.class)
     public void testInvalidTreatmentName() throws ValidationException {
-        final TreatmentOverride override = new TreatmentOverride("an invalid name with spaces", mock(FilterExpression.class),treatment);
+        final TreatmentOverride override =
+                new TreatmentOverride(
+                        "an invalid name with spaces", mock(FilterExpression.class), treatment);
         override.validateName();
     }
 }

--- a/alchemy-core/src/test/java/io/rtr/alchemy/models/TreatmentTest.java
+++ b/alchemy-core/src/test/java/io/rtr/alchemy/models/TreatmentTest.java
@@ -10,10 +10,7 @@ import static org.junit.Assert.assertEquals;
 public class TreatmentTest {
     @Test
     public void testEqualsHashCode() {
-        EqualsVerifier
-            .forClass(Treatment.class)
-            .suppress(Warning.STRICT_INHERITANCE)
-            .verify();
+        EqualsVerifier.forClass(Treatment.class).suppress(Warning.STRICT_INHERITANCE).verify();
     }
 
     @Test
@@ -28,5 +25,4 @@ public class TreatmentTest {
         final Treatment treatment = new Treatment(";;;", "a treatment with an invalid name");
         treatment.validateName();
     }
-
 }

--- a/alchemy-db-memory/src/main/java/io/rtr/alchemy/db/memory/MemoryExperimentsCache.java
+++ b/alchemy-db-memory/src/main/java/io/rtr/alchemy/db/memory/MemoryExperimentsCache.java
@@ -9,12 +9,11 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Map.Entry;
 
-/**
- * Implements a cache that caches experiments in memory
- */
+/** Implements a cache that caches experiments in memory */
 public class MemoryExperimentsCache implements ExperimentsCache {
     private static final ActiveFilter ACTIVE_FILTER = new ActiveFilter();
-    private static final ExperimentCopyTransformer EXPERIMENT_COPY_TRANSFORMER = new ExperimentCopyTransformer();
+    private static final ExperimentCopyTransformer EXPERIMENT_COPY_TRANSFORMER =
+            new ExperimentCopyTransformer();
     private final Map<String, Experiment> db;
 
     public MemoryExperimentsCache(Map<String, Experiment> db) {
@@ -28,20 +27,16 @@ public class MemoryExperimentsCache implements ExperimentsCache {
     }
 
     @Override
-    public void invalidateAll(Experiment.BuilderFactory factory) {
-    }
+    public void invalidateAll(Experiment.BuilderFactory factory) {}
 
     @Override
-    public void invalidate(String experimentName, Experiment.Builder builder) {
-    }
+    public void invalidate(String experimentName, Experiment.Builder builder) {}
 
     @Override
-    public void update(Experiment experiment) {
-    }
+    public void update(Experiment experiment) {}
 
     @Override
-    public void delete(String experimentName) {
-    }
+    public void delete(String experimentName) {}
 
     @Override
     public boolean checkIfAnyStale() {
@@ -60,7 +55,8 @@ public class MemoryExperimentsCache implements ExperimentsCache {
         }
     }
 
-    private static class ExperimentCopyTransformer implements Maps.EntryTransformer<String, Experiment, Experiment> {
+    private static class ExperimentCopyTransformer
+            implements Maps.EntryTransformer<String, Experiment, Experiment> {
         @Override
         public Experiment transformEntry(@Nullable String key, @Nullable Experiment value) {
             return value == null ? null : Experiment.copyOf(value);

--- a/alchemy-db-memory/src/main/java/io/rtr/alchemy/db/memory/MemoryExperimentsStore.java
+++ b/alchemy-db-memory/src/main/java/io/rtr/alchemy/db/memory/MemoryExperimentsStore.java
@@ -17,9 +17,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
-/**
- * Implements a store that stores experiments in memory
- */
+/** Implements a store that stores experiments in memory */
 public class MemoryExperimentsStore implements ExperimentsStore {
     private final Map<String, Experiment> db;
 
@@ -42,7 +40,7 @@ public class MemoryExperimentsStore implements ExperimentsStore {
         db.remove(experimentName);
     }
 
-    private static boolean filterMatches(String filter, Object ... values) {
+    private static boolean filterMatches(String filter, Object... values) {
         if (filter == null || filter.isEmpty()) {
             return true;
         }
@@ -109,12 +107,9 @@ public class MemoryExperimentsStore implements ExperimentsStore {
 
                     default:
                         throw new IllegalArgumentException(
-                            String.format(
-                                "Unsupported ordering field: %s (%s)",
-                                field,
-                                field.getName()
-                            )
-                        );
+                                String.format(
+                                        "Unsupported ordering field: %s (%s)",
+                                        field, field.getName()));
                 }
             }
 
@@ -128,9 +123,7 @@ public class MemoryExperimentsStore implements ExperimentsStore {
 
         for (final Experiment experiment : db.values()) {
             if (filterMatches(
-                filter.getFilter(),
-                experiment.getName(),
-                experiment.getDescription())) {
+                    filter.getFilter(), experiment.getName(), experiment.getDescription())) {
                 result.add(Experiment.copyOf(experiment));
             }
         }

--- a/alchemy-db-memory/src/main/java/io/rtr/alchemy/db/memory/MemoryStoreProvider.java
+++ b/alchemy-db-memory/src/main/java/io/rtr/alchemy/db/memory/MemoryStoreProvider.java
@@ -9,9 +9,7 @@ import io.rtr.alchemy.models.Experiment;
 import java.io.IOException;
 import java.util.Map;
 
-/**
- * A store provider storing and caching experiments in memory
- */
+/** A store provider storing and caching experiments in memory */
 public class MemoryStoreProvider implements ExperimentsStoreProvider {
     private final Map<String, Experiment> db = Maps.newConcurrentMap();
 

--- a/alchemy-db-memory/src/test/java/io/rtr/alchemy/db/memory/MemoryStoreProviderTest.java
+++ b/alchemy-db-memory/src/test/java/io/rtr/alchemy/db/memory/MemoryStoreProviderTest.java
@@ -1,6 +1,5 @@
 package io.rtr.alchemy.db.memory;
 
-
 import io.rtr.alchemy.db.ExperimentsStoreProvider;
 import io.rtr.alchemy.testing.db.ExperimentsStoreProviderTest;
 

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/MongoExperimentsCache.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/MongoExperimentsCache.java
@@ -10,9 +10,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
-/**
- * A cache backed by MongoDB which allows for quick cached access to Experiments
- */
+/** A cache backed by MongoDB which allows for quick cached access to Experiments */
 public class MongoExperimentsCache implements ExperimentsCache {
     private final RevisionManager revisionManager;
     private final Datastore ds;
@@ -26,10 +24,7 @@ public class MongoExperimentsCache implements ExperimentsCache {
     @Override
     public void invalidateAll(Experiment.BuilderFactory factory) {
         final Iterator<ExperimentEntity> iterator =
-            ds
-                .find(ExperimentEntity.class)
-                .field("active").equal(true)
-                .iterator();
+                ds.find(ExperimentEntity.class).field("active").equal(true).iterator();
 
         final Map<String, Experiment> newMap = Maps.newConcurrentMap();
         Long maxRevision = null;
@@ -64,7 +59,6 @@ public class MongoExperimentsCache implements ExperimentsCache {
         } else {
             cachedExperiments.remove(experimentName);
         }
-
     }
 
     @Override

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/MongoExperimentsStore.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/MongoExperimentsStore.java
@@ -13,9 +13,7 @@ import org.mongodb.morphia.query.Query;
 
 import java.util.Map.Entry;
 
-/**
- * A store backed by MongoDB which allows storing Experiments
- */
+/** A store backed by MongoDB which allows storing Experiments */
 public class MongoExperimentsStore implements ExperimentsStore {
     private final AdvancedDatastore ds;
     private final RevisionManager revisionManager;
@@ -35,10 +33,7 @@ public class MongoExperimentsStore implements ExperimentsStore {
     @Override
     public Experiment load(String experimentName, Experiment.Builder builder) {
         final ExperimentEntity entity = ds.get(ExperimentEntity.class, experimentName);
-        return
-            entity == null ?
-                null :
-                entity.toExperiment(builder);
+        return entity == null ? null : entity.toExperiment(builder);
     }
 
     @Override
@@ -53,9 +48,8 @@ public class MongoExperimentsStore implements ExperimentsStore {
 
         if (filter.getFilter() != null) {
             query.or(
-                query.criteria("name").containsIgnoreCase(filter.getFilter()),
-                query.criteria("description").containsIgnoreCase(filter.getFilter())
-            );
+                    query.criteria("name").containsIgnoreCase(filter.getFilter()),
+                    query.criteria("description").containsIgnoreCase(filter.getFilter()));
         }
 
         final Ordering ordering = filter.getOrdering();

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/MongoStoreProvider.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/MongoStoreProvider.java
@@ -14,9 +14,7 @@ import org.mongodb.morphia.Morphia;
 
 import java.util.List;
 
-/**
- * A provider for MongoDB which implements the store and cache for using MongoDB as a backend
- */
+/** A provider for MongoDB which implements the store and cache for using MongoDB as a backend */
 public class MongoStoreProvider implements ExperimentsStoreProvider {
     private final MongoClient client;
     private final ExperimentsStore store;
@@ -26,16 +24,16 @@ public class MongoStoreProvider implements ExperimentsStoreProvider {
         return new Builder();
     }
 
-    private MongoStoreProvider(List<ServerAddress> hosts,
-                               List<MongoCredential> credentials,
-                               MongoClientOptions options,
-                               String database) {
+    private MongoStoreProvider(
+            List<ServerAddress> hosts,
+            List<MongoCredential> credentials,
+            MongoClientOptions options,
+            String database) {
         this(
-            options == null ?
-            new MongoClient(hosts, credentials) :
-            new MongoClient(hosts, credentials, options),
-            database
-        );
+                options == null
+                        ? new MongoClient(hosts, credentials)
+                        : new MongoClient(hosts, credentials, options),
+                database);
     }
 
     public MongoStoreProvider(MongoClient client, String database) {
@@ -99,15 +97,12 @@ public class MongoStoreProvider implements ExperimentsStoreProvider {
 
         public MongoStoreProvider build() {
             if (hosts.isEmpty()) {
-                hosts.add(new ServerAddress(ServerAddress.defaultHost(), ServerAddress.defaultPort()));
+                hosts.add(
+                        new ServerAddress(
+                                ServerAddress.defaultHost(), ServerAddress.defaultPort()));
             }
 
-            return new MongoStoreProvider(
-                hosts,
-                credentials,
-                options,
-                database
-            );
+            return new MongoStoreProvider(hosts, credentials, options, database);
         }
     }
 }

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/RevisionManager.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/RevisionManager.java
@@ -5,9 +5,7 @@ import io.rtr.alchemy.db.mongo.models.ExperimentEntity;
 import io.rtr.alchemy.db.mongo.models.MetadataEntity;
 import org.mongodb.morphia.AdvancedDatastore;
 
-/**
- * Manages what revision experiments are at in order to check when experiments are stale
- */
+/** Manages what revision experiments are at in order to check when experiments are stale */
 public class RevisionManager {
     private static final String NAME = "revision";
     private final AdvancedDatastore ds;
@@ -47,12 +45,11 @@ public class RevisionManager {
     }
 
     public long nextRevision() {
-        return
-            (Long) ds
-                .findAndModify(
-                    ds.createQuery(MetadataEntity.class).field("name").equal(NAME),
-                    ds.createUpdateOperations(MetadataEntity.class).inc("value")
-                ).value;
+        return (Long)
+                ds.findAndModify(
+                                ds.createQuery(MetadataEntity.class).field("name").equal(NAME),
+                                ds.createUpdateOperations(MetadataEntity.class).inc("value"))
+                        .value;
     }
 
     public void setLatestRevision(Long revision) {

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/AllocationEntity.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/AllocationEntity.java
@@ -5,6 +5,7 @@ import org.mongodb.morphia.annotations.Embedded;
 
 /**
  * An entity that mirrors Allocation
+ *
  * @see io.rtr.alchemy.models.Allocation
  */
 @Embedded
@@ -18,7 +19,7 @@ public class AllocationEntity {
     }
 
     // Required by Morphia
-    private AllocationEntity() { }
+    private AllocationEntity() {}
 
     private AllocationEntity(Allocation allocation) {
         this.treatment = allocation.getTreatment().getName();

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/ExperimentEntity.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/ExperimentEntity.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 /**
  * An entity that mirrors Experiment
+ *
  * @see io.rtr.alchemy.models.Experiment
  */
 @Entity(value = "Experiments", noClassnameStored = true)
@@ -28,11 +29,11 @@ import java.util.List;
 public class ExperimentEntity {
     private static final TreatmentMapper TREATMENT_MAPPER = new TreatmentMapper();
     private static final AllocationMapper ALLOCATION_MAPPER = new AllocationMapper();
-    private static final TreatmentOverrideMapper TREATMENT_OVERRIDE_MAPPER = new TreatmentOverrideMapper();
+    private static final TreatmentOverrideMapper TREATMENT_OVERRIDE_MAPPER =
+            new TreatmentOverrideMapper();
 
     public static final String FIELD_NAME = "name";
-    @Id
-    public String name;
+    @Id public String name;
 
     public int seed;
 
@@ -43,8 +44,7 @@ public class ExperimentEntity {
     public List<String> hashAttributes;
 
     public static final String FIELD_ACTIVE = "active";
-    @Indexed
-    public boolean active;
+    @Indexed public boolean active;
 
     public long revision;
 
@@ -60,14 +60,11 @@ public class ExperimentEntity {
     public static final String FIELD_DEACTIVATED = "deactivated";
     public DateTime deactivated;
 
-    @Embedded
-    public List<TreatmentEntity> treatments;
+    @Embedded public List<TreatmentEntity> treatments;
 
-    @Embedded
-    public List<AllocationEntity> allocations;
+    @Embedded public List<AllocationEntity> allocations;
 
-    @Embedded
-    public List<TreatmentOverrideEntity> overrides;
+    @Embedded public List<TreatmentOverrideEntity> overrides;
 
     public static ExperimentEntity from(Experiment experiment) {
         return new ExperimentEntity(experiment);
@@ -78,7 +75,7 @@ public class ExperimentEntity {
             case NAME:
                 return ExperimentEntity.FIELD_NAME;
             case DESCRIPTION:
-                return  ExperimentEntity.FIELD_DESCRIPTION;
+                return ExperimentEntity.FIELD_DESCRIPTION;
             case ACTIVE:
                 return ExperimentEntity.FIELD_ACTIVE;
             case CREATED:
@@ -91,26 +88,21 @@ public class ExperimentEntity {
                 return ExperimentEntity.FIELD_DEACTIVATED;
             default:
                 throw new IllegalArgumentException(
-                    String.format(
-                        "Unsupported ordering field: %s (%s)",
-                        field,
-                        field.getName()
-                    )
-                );
+                        String.format(
+                                "Unsupported ordering field: %s (%s)", field, field.getName()));
         }
     }
 
     public Experiment toExperiment(Experiment.Builder builder) {
-        builder
-            .seed(seed)
-            .description(description)
-            .filter(filter)
-            .hashAttributes(Sets.newLinkedHashSet(hashAttributes))
-            .created(created)
-            .modified(modified)
-            .activated(activated)
-            .deactivated(deactivated)
-            .active(active);
+        builder.seed(seed)
+                .description(description)
+                .filter(filter)
+                .hashAttributes(Sets.newLinkedHashSet(hashAttributes))
+                .created(created)
+                .modified(modified)
+                .activated(activated)
+                .deactivated(deactivated)
+                .active(active);
 
         if (treatments != null) {
             for (final TreatmentEntity treatment : treatments) {
@@ -134,7 +126,7 @@ public class ExperimentEntity {
     }
 
     // Required by Morphia
-    private ExperimentEntity() { }
+    private ExperimentEntity() {}
 
     private ExperimentEntity(Experiment experiment) {
         name = experiment.getName();
@@ -147,9 +139,11 @@ public class ExperimentEntity {
         deactivated = experiment.getDeactivated();
         filter = experiment.getFilter().toString();
         hashAttributes = Lists.newArrayList(experiment.getHashAttributes());
-        treatments = Lists.newArrayList(Collections2.transform(experiment.getTreatments(), TREATMENT_MAPPER));
+        treatments =
+                Lists.newArrayList(
+                        Collections2.transform(experiment.getTreatments(), TREATMENT_MAPPER));
         allocations = Lists.transform(experiment.getAllocations(), ALLOCATION_MAPPER);
-        overrides = Lists.transform(experiment.getOverrides(),TREATMENT_OVERRIDE_MAPPER);
+        overrides = Lists.transform(experiment.getOverrides(), TREATMENT_OVERRIDE_MAPPER);
     }
 
     private static class TreatmentMapper implements Function<Treatment, TreatmentEntity> {
@@ -168,7 +162,8 @@ public class ExperimentEntity {
         }
     }
 
-    private static class TreatmentOverrideMapper implements Function<TreatmentOverride, TreatmentOverrideEntity> {
+    private static class TreatmentOverrideMapper
+            implements Function<TreatmentOverride, TreatmentOverrideEntity> {
         @Nullable
         @Override
         public TreatmentOverrideEntity apply(@Nullable TreatmentOverride input) {

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/MetadataEntity.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/MetadataEntity.java
@@ -4,25 +4,20 @@ import org.mongodb.morphia.annotations.Entity;
 import org.mongodb.morphia.annotations.Id;
 import org.mongodb.morphia.annotations.Property;
 
-/**
- * An entity for storing additional metadata
- */
+/** An entity for storing additional metadata */
 @Entity(value = "Metadata", noClassnameStored = true)
 public class MetadataEntity {
 
-    @Id
-    public String name;
+    @Id public String name;
 
-    @Property
-    public Object value;
+    @Property public Object value;
 
     public static MetadataEntity of(String name, Object value) {
         return new MetadataEntity(name, value);
     }
 
     // Required by Morphia
-    private MetadataEntity() {
-    }
+    private MetadataEntity() {}
 
     private MetadataEntity(String name, Object value) {
         this.name = name;

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/TreatmentEntity.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/TreatmentEntity.java
@@ -5,6 +5,7 @@ import org.mongodb.morphia.annotations.Embedded;
 
 /**
  * An entity that mirrors Treatment
+ *
  * @see io.rtr.alchemy.models.Treatment
  */
 @Embedded
@@ -17,7 +18,7 @@ public class TreatmentEntity {
     }
 
     // Required by Morphia
-    private TreatmentEntity() { }
+    private TreatmentEntity() {}
 
     private TreatmentEntity(Treatment treatment) {
         name = treatment.getName();

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/TreatmentOverrideEntity.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/models/TreatmentOverrideEntity.java
@@ -5,6 +5,7 @@ import org.mongodb.morphia.annotations.Embedded;
 
 /**
  * An entity that mirrors TreatmentOverride
+ *
  * @see io.rtr.alchemy.models.TreatmentOverride
  */
 @Embedded
@@ -18,7 +19,7 @@ public class TreatmentOverrideEntity {
     }
 
     // Required by Morphia
-    private TreatmentOverrideEntity() { }
+    private TreatmentOverrideEntity() {}
 
     private TreatmentOverrideEntity(TreatmentOverride override) {
         this.name = override.getName();

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/util/DateTimeConverter.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/util/DateTimeConverter.java
@@ -5,9 +5,7 @@ import org.mongodb.morphia.converters.SimpleValueConverter;
 import org.mongodb.morphia.converters.TypeConverter;
 import org.mongodb.morphia.mapping.MappedField;
 
-/**
- * A morphia converter for Joda Time
- */
+/** A morphia converter for Joda Time */
 public class DateTimeConverter extends TypeConverter implements SimpleValueConverter {
     protected DateTimeConverter() {
         super(DateTime.class);

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/util/ExceptionSafeIterator.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/util/ExceptionSafeIterator.java
@@ -7,7 +7,9 @@ import org.slf4j.LoggerFactory;
 import java.util.Iterator;
 
 /**
- * Ensures that if there's a problem loading an entity that we don't fail loading the rest but instead just skip over it
+ * Ensures that if there's a problem loading an entity that we don't fail loading the rest but
+ * instead just skip over it
+ *
  * @param <T> The type of thing we're iterating over
  */
 public class ExceptionSafeIterator<T> implements Iterator<T> {
@@ -17,20 +19,23 @@ public class ExceptionSafeIterator<T> implements Iterator<T> {
     private boolean nextCalled;
 
     private ExceptionSafeIterator(final Iterator<T> iterator) {
-        this.abstractIterator = new AbstractIterator<T>() {
-            @Override
-            protected T computeNext() {
-                while(iterator.hasNext()) {
-                    try {
-                        return iterator.next();
-                    } catch (Exception e) {
-                        LOG.error("failed to retrieve next item from iterator, skipping item", e);
-                    }
-                }
+        this.abstractIterator =
+                new AbstractIterator<T>() {
+                    @Override
+                    protected T computeNext() {
+                        while (iterator.hasNext()) {
+                            try {
+                                return iterator.next();
+                            } catch (Exception e) {
+                                LOG.error(
+                                        "failed to retrieve next item from iterator, skipping item",
+                                        e);
+                            }
+                        }
 
-                return endOfData();
-            }
-        };
+                        return endOfData();
+                    }
+                };
         this.iterator = iterator;
     }
 
@@ -50,15 +55,19 @@ public class ExceptionSafeIterator<T> implements Iterator<T> {
         return abstractIterator.next();
     }
 
-    // AbstractIterator<T> doesn't support remove(), because it peeks ahead and can cause ambiguity as to which element
-    // is being removed.  Here we make a compromise where assuming that next() has been called after a hasNext(), which
+    // AbstractIterator<T> doesn't support remove(), because it peeks ahead and can cause ambiguity
+    // as to which element
+    // is being removed.  Here we make a compromise where assuming that next() has been called after
+    // a hasNext(), which
     // is the most common use case, we can safely call remove()
     @Override
     public void remove() {
         if (!nextCalled) {
-            // because elements are peeked in advanced, to avoid confusion as to which element is being been removed
+            // because elements are peeked in advanced, to avoid confusion as to which element is
+            // being been removed
             // one must first call next() after calling hasNext() before being able to call remove()
-            throw new UnsupportedOperationException("cannot remove element until next() has been called after calling hasNext()");
+            throw new UnsupportedOperationException(
+                    "cannot remove element until next() has been called after calling hasNext()");
         }
         iterator.remove();
     }

--- a/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/util/ExperimentIterable.java
+++ b/alchemy-db-mongo/src/main/java/io/rtr/alchemy/db/mongo/util/ExperimentIterable.java
@@ -6,13 +6,15 @@ import io.rtr.alchemy.models.Experiment;
 import java.util.Iterator;
 
 /**
- * An iterator that iterates over ExperimentEntity results and maps them to actual Experiment instances
+ * An iterator that iterates over ExperimentEntity results and maps them to actual Experiment
+ * instances
  */
 public class ExperimentIterable implements Iterable<Experiment> {
     private final Iterator<ExperimentEntity> iterator;
     private final Experiment.BuilderFactory factory;
 
-    public ExperimentIterable(Iterator<ExperimentEntity> iterator, Experiment.BuilderFactory factory) {
+    public ExperimentIterable(
+            Iterator<ExperimentEntity> iterator, Experiment.BuilderFactory factory) {
         this.iterator = iterator;
         this.factory = factory;
     }
@@ -20,23 +22,22 @@ public class ExperimentIterable implements Iterable<Experiment> {
     @Override
     public Iterator<Experiment> iterator() {
         return ExceptionSafeIterator.wrap(
-            new Iterator<Experiment>() {
-                @Override
-                public boolean hasNext() {
-                    return iterator.hasNext();
-                }
+                new Iterator<Experiment>() {
+                    @Override
+                    public boolean hasNext() {
+                        return iterator.hasNext();
+                    }
 
-                @Override
-                public Experiment next() {
-                    final ExperimentEntity entity = iterator.next();
-                    return entity.toExperiment(factory.createBuilder(entity.name));
-                }
+                    @Override
+                    public Experiment next() {
+                        final ExperimentEntity entity = iterator.next();
+                        return entity.toExperiment(factory.createBuilder(entity.name));
+                    }
 
-                @Override
-                public void remove() {
-                    iterator.remove();
-                }
-            }
-        );
+                    @Override
+                    public void remove() {
+                        iterator.remove();
+                    }
+                });
     }
 }

--- a/alchemy-db-mongo/src/test/java/io/rtr/alchemy/db/mongo/MongoStoreProviderTest.java
+++ b/alchemy-db-mongo/src/test/java/io/rtr/alchemy/db/mongo/MongoStoreProviderTest.java
@@ -14,10 +14,7 @@ public class MongoStoreProviderTest extends ExperimentsStoreProviderTest {
 
     @Override
     protected ExperimentsStoreProvider createProvider() throws Exception {
-        return MongoStoreProvider
-            .newBuilder()
-            .setDatabase(DATABASE_NAME)
-            .build();
+        return MongoStoreProvider.newBuilder().setDatabase(DATABASE_NAME).build();
     }
 
     @Override

--- a/alchemy-db-mongo/src/test/java/io/rtr/alchemy/db/mongo/RevisionManagerTest.java
+++ b/alchemy-db-mongo/src/test/java/io/rtr/alchemy/db/mongo/RevisionManagerTest.java
@@ -32,19 +32,25 @@ public class RevisionManagerTest {
     public void setUp() {
         revision = Long.MIN_VALUE;
         ds = mock(AdvancedDatastore.class);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                return MetadataEntity.of("revision", revision);
-            }
-        }).when(ds).get(eq(MetadataEntity.class), anyString());
+        doAnswer(
+                        new Answer() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                return MetadataEntity.of("revision", revision);
+                            }
+                        })
+                .when(ds)
+                .get(eq(MetadataEntity.class), anyString());
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                return MetadataEntity.of("revision", ++revision);
-            }
-        }).when(ds).findAndModify(any(Query.class), any(UpdateOperations.class));
+        doAnswer(
+                        new Answer() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                return MetadataEntity.of("revision", ++revision);
+                            }
+                        })
+                .when(ds)
+                .findAndModify(any(Query.class), any(UpdateOperations.class));
 
         final Query query = mock(Query.class);
         final FieldEnd fieldEnd = mock(FieldEnd.class);
@@ -58,14 +64,18 @@ public class RevisionManagerTest {
     }
 
     private void makeInsertSetRevision() {
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                final MetadataEntity entity = (MetadataEntity) invocation.getArguments()[0];
-                revision = (Long) entity.value;
-                return null;
-            }
-        }).when(ds).insert(any(Object.class));
+        doAnswer(
+                        new Answer() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                final MetadataEntity entity =
+                                        (MetadataEntity) invocation.getArguments()[0];
+                                revision = (Long) entity.value;
+                                return null;
+                            }
+                        })
+                .when(ds)
+                .insert(any(Object.class));
     }
 
     @Test
@@ -106,14 +116,17 @@ public class RevisionManagerTest {
     @Test
     public void testSetLatestRevision() {
         // our experiment will always be at revision Long.MIN_VALUE + 1
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                final ExperimentEntity entity = mock(ExperimentEntity.class);
-                entity.revision = Long.MIN_VALUE + 1;
-                return entity;
-            }
-        }).when(ds).get(eq(ExperimentEntity.class), anyString());
+        doAnswer(
+                        new Answer() {
+                            @Override
+                            public Object answer(InvocationOnMock invocation) throws Throwable {
+                                final ExperimentEntity entity = mock(ExperimentEntity.class);
+                                entity.revision = Long.MIN_VALUE + 1;
+                                return entity;
+                            }
+                        })
+                .when(ds)
+                .get(eq(ExperimentEntity.class), anyString());
 
         final RevisionManager revisionManager = new RevisionManager(ds);
 
@@ -122,11 +135,12 @@ public class RevisionManagerTest {
         assertFalse(revisionManager.checkIfAnyStale());
         assertTrue(revisionManager.checkIfStale("foo"));
 
-        revision = Long.MIN_VALUE + 1;  // our databases' revision
+        revision = Long.MIN_VALUE + 1; // our databases' revision
         revisionManager.setLatestRevision(Long.MIN_VALUE); // revision manager's internal revision
         assertTrue(revisionManager.checkIfAnyStale());
 
-        revisionManager.setLatestRevision(Long.MIN_VALUE + 1); // revision manager's internal revision
+        revisionManager.setLatestRevision(
+                Long.MIN_VALUE + 1); // revision manager's internal revision
         assertFalse(revisionManager.checkIfStale("foo"));
     }
 }

--- a/alchemy-db-mongo/src/test/java/io/rtr/alchemy/db/mongo/util/ExceptionSafeIteratorTest.java
+++ b/alchemy-db-mongo/src/test/java/io/rtr/alchemy/db/mongo/util/ExceptionSafeIteratorTest.java
@@ -17,45 +17,47 @@ import static org.junit.Assert.assertTrue;
 public class ExceptionSafeIteratorTest {
     @Test
     public void testIteratorWithExceptions() {
-        final Iterator<Integer> throwIterator = new Iterator<Integer>() {
-            private final Integer[] numbers = { 0, 1, null, 2, null, null, 3, null, null };
-            private int n = 0;
+        final Iterator<Integer> throwIterator =
+                new Iterator<Integer>() {
+                    private final Integer[] numbers = {0, 1, null, 2, null, null, 3, null, null};
+                    private int n = 0;
 
-            @Override
-            public boolean hasNext() {
-                return n < numbers.length;
-            }
+                    @Override
+                    public boolean hasNext() {
+                        return n < numbers.length;
+                    }
 
-            @Override
-            public Integer next() {
-                if (numbers[n] == null) {
-                    n++;
-                    throw new UnsupportedOperationException();
-                }
+                    @Override
+                    public Integer next() {
+                        if (numbers[n] == null) {
+                            n++;
+                            throw new UnsupportedOperationException();
+                        }
 
-                return numbers[n++];
-            }
+                        return numbers[n++];
+                    }
 
-            @Override
-            public void remove() {
-            }
-        };
+                    @Override
+                    public void remove() {}
+                };
 
         final Iterator<Integer> evens = ExceptionSafeIterator.wrap(throwIterator);
 
-        assertArrayEquals(new Integer[]{0, 1, 2, 3}, Iterators.toArray(evens, Integer.class));
+        assertArrayEquals(new Integer[] {0, 1, 2, 3}, Iterators.toArray(evens, Integer.class));
     }
 
     @Test(expected = NoSuchElementException.class)
     public void testIteratorExhausted() {
-        final Iterator<Integer> emptyIterator = ExceptionSafeIterator.wrap(Collections.<Integer>emptyIterator());
+        final Iterator<Integer> emptyIterator =
+                ExceptionSafeIterator.wrap(Collections.<Integer>emptyIterator());
         assertFalse(emptyIterator.hasNext());
         emptyIterator.next();
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testIteratorRemoveWithoutNext() {
-        final Iterator<Integer> iterator = ExceptionSafeIterator.wrap(Lists.newArrayList(1, 2, 3).iterator());
+        final Iterator<Integer> iterator =
+                ExceptionSafeIterator.wrap(Lists.newArrayList(1, 2, 3).iterator());
         assertTrue(iterator.hasNext());
         iterator.next();
         assertTrue(iterator.hasNext());

--- a/alchemy-example/pom.xml
+++ b/alchemy-example/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
+        <version>${maven-shade-plugin.version}</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <filters>

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/ClientExample.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/ClientExample.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * Example code that utilizes the alchemy-client library to talk to an instance of Alchemy service
  */
 public class ClientExample {
-    private static void println(String formatMessage, Object ... args) {
+    private static void println(String formatMessage, Object... args) {
         System.out.println(String.format(formatMessage, args));
     }
 
@@ -40,15 +40,10 @@ public class ClientExample {
         final ObjectMapper mapper = Jackson.newObjectMapper();
         mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         final ConfigurationFactory<AlchemyClientConfiguration> configurationFactory =
-            new DefaultConfigurationFactoryFactory<AlchemyClientConfiguration>().create(
-                AlchemyClientConfiguration.class,
-                validator,
-                mapper,
-                "");
+                new DefaultConfigurationFactoryFactory<AlchemyClientConfiguration>()
+                        .create(AlchemyClientConfiguration.class, validator, mapper, "");
 
-        return new AlchemyClient(
-            configurationFactory.build(new File(configurationFile))
-        );
+        return new AlchemyClient(configurationFactory.build(new File(configurationFile)));
     }
 
     private static void disableLogging() {
@@ -68,22 +63,20 @@ public class ClientExample {
             final AlchemyClient client = buildClient(args[0]);
 
             // Let's create our experiment
-            client
-                .createExperiment("my_experiment")
-                .setDescription("my new experiment")
-                .addTreatment("control", "the default")
-                .addTreatment("pie", "show them pie")
-                .setFilter("identified")
-                .allocate("control", 25)
-                .allocate("pie", 25)
-                .activate()
-                .apply();
+            client.createExperiment("my_experiment")
+                    .setDescription("my new experiment")
+                    .addTreatment("control", "the default")
+                    .addTreatment("pie", "show them pie")
+                    .setFilter("identified")
+                    .allocate("control", 25)
+                    .allocate("pie", 25)
+                    .activate()
+                    .apply();
 
             // Actually, the description should be more descriptive
-            client
-                .updateExperiment("my_experiment")
-                .setDescription("my experiment to see if people like pie")
-                .apply();
+            client.updateExperiment("my_experiment")
+                    .setDescription("my experiment to see if people like pie")
+                    .apply();
 
             // Let's get our experiment and print it out
             final ExperimentDto experiment = client.getExperiment("my_experiment");
@@ -101,14 +94,13 @@ public class ClientExample {
 
             // Let's also add for comparison, cake
             client.addTreatment("my_experiment", "cake", "show them cake");
-            client
-                .updateAllocations("my_experiment")
-                .allocate("cake", 25)
-                .apply();
+            client.updateAllocations("my_experiment").allocate("cake", 25).apply();
 
             // Let's print out our allocations
             for (final AllocationDto allocation : client.getAllocations("my_experiment")) {
-                println("treatment: %s, offset: %d, size: %d", allocation.getTreatment(), allocation.getOffset(), allocation.getSize());
+                println(
+                        "treatment: %s, offset: %d, size: %d",
+                        allocation.getTreatment(), allocation.getOffset(), allocation.getSize());
             }
             println();
 
@@ -125,21 +117,19 @@ public class ClientExample {
             client.clearTreatments("my_experiment");
             client.addTreatment("my_experiment", "beer", "beer me!");
             client.addTreatment("my_experiment", "wine", "wine please");
-            client
-                .updateAllocations("my_experiment")
-                .allocate("beer", 90) // slightly biased
-                .allocate("wine", 10)
-                .apply();
+            client.updateAllocations("my_experiment")
+                    .allocate("beer", 90) // slightly biased
+                    .allocate("wine", 10)
+                    .apply();
 
             // Ok, that was unfair, let's fix the allocations
             client.clearAllocations("my_experiment");
             client.addOverride("my_experiment", "gene_likes_beer", "beer", "user_name=gene");
             client.addOverride("my_experiment", "qa_wine", "wine", "user_name=qa");
-            client
-                .updateAllocations("my_experiment")
-                .allocate("beer", 51)
-                .allocate("wine", 49)
-                .apply();
+            client.updateAllocations("my_experiment")
+                    .allocate("beer", 51)
+                    .allocate("wine", 49)
+                    .apply();
 
             // Print out an override
             final TreatmentOverrideDto override = client.getOverride("my_experiment", "qa_wine");
@@ -147,17 +137,20 @@ public class ClientExample {
             println();
 
             // Let's query our active experiments
-            final TreatmentDto activeTreatment = client.getActiveTreatment("my_experiment", new UserDto("gene"));
-            println("name: %s, description: %s", activeTreatment.getName(), activeTreatment.getDescription());
+            final TreatmentDto activeTreatment =
+                    client.getActiveTreatment("my_experiment", new UserDto("gene"));
+            println(
+                    "name: %s, description: %s",
+                    activeTreatment.getName(), activeTreatment.getDescription());
             println();
 
-            for (final Map.Entry<String, TreatmentDto> entry : client.getActiveTreatments(new UserDto("qa")).entrySet()) {
+            for (final Map.Entry<String, TreatmentDto> entry :
+                    client.getActiveTreatments(new UserDto("qa")).entrySet()) {
                 println(
-                    "experiment: %s, treatment: %s, description: %s",
-                    entry.getKey(),
-                    entry.getValue().getName(),
-                    entry.getValue().getDescription()
-                );
+                        "experiment: %s, treatment: %s, description: %s",
+                        entry.getKey(),
+                        entry.getValue().getName(),
+                        entry.getValue().getDescription());
             }
             println();
 
@@ -175,7 +168,9 @@ public class ClientExample {
             client.deleteExperiment("my_experiment");
 
         } catch (final WebApplicationException uie) {
-            println("ERROR, HTTP %d: %s", uie.getResponse().getStatus(), uie.getResponse().getEntity());
+            println(
+                    "ERROR, HTTP %d: %s",
+                    uie.getResponse().getStatus(), uie.getResponse().getEntity());
         }
     }
 }

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/LibraryExample.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/LibraryExample.java
@@ -22,16 +22,14 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Example code that utilizes the alchemy-core library to interact with experiments directly
- */
+/** Example code that utilizes the alchemy-core library to interact with experiments directly */
 public class LibraryExample {
     private static void disableLogging() {
         final Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         root.setLevel(Level.ERROR);
     }
 
-    private static void println(String formatMessage, Object ... args) {
+    private static void println(String formatMessage, Object... args) {
         System.out.println(String.format(formatMessage, args));
     }
 
@@ -39,32 +37,30 @@ public class LibraryExample {
         System.out.println();
     }
 
-    /**
-     * This example performs some basic operations on an instance of Experiments directly
-     */
+    /** This example performs some basic operations on an instance of Experiments directly */
     public static void main(String[] args) throws IOException {
         disableLogging();
 
-        try(final ExperimentsStoreProvider provider = new MemoryStoreProvider();
-            final Experiments experiments = Experiments.using(provider).build()) {
+        try (final ExperimentsStoreProvider provider = new MemoryStoreProvider();
+                final Experiments experiments = Experiments.using(provider).build()) {
 
             // Let's create our experiment
             experiments
-                .create("my_experiment")
-                .setDescription("my new experiment")
-                .addTreatment("control", "the default")
-                .addTreatment("pie", "show them pie")
-                .setFilter(FilterExpression.of("identified"))
-                .allocate("control", 25)
-                .allocate("pie", 25)
-                .activate()
-                .save();
+                    .create("my_experiment")
+                    .setDescription("my new experiment")
+                    .addTreatment("control", "the default")
+                    .addTreatment("pie", "show them pie")
+                    .setFilter(FilterExpression.of("identified"))
+                    .allocate("control", 25)
+                    .allocate("pie", 25)
+                    .activate()
+                    .save();
 
             // Actually, the description should be more descriptive
             experiments
-                .get("my_experiment")
-                .setDescription("my experiment to see if people like pie")
-                .save();
+                    .get("my_experiment")
+                    .setDescription("my experiment to see if people like pie")
+                    .save();
 
             // Let's get our experiment and print it out
             final Experiment experiment = experiments.get("my_experiment");
@@ -78,24 +74,18 @@ public class LibraryExample {
             println();
 
             // Let's add an override for our qa person, who obviously likes pie
-            experiment
-                .addOverride("qa_pie", "pie", "user_name=qa")
-                .save();
+            experiment.addOverride("qa_pie", "pie", "user_name=qa").save();
 
             // Let's also add for comparison, cake
-            experiment
-                .addTreatment("cake", "show them cake")
-                .allocate("cake", 25)
-                .save();
+            experiment.addTreatment("cake", "show them cake").allocate("cake", 25).save();
 
             // Let's print out our allocations
             for (final Allocation allocation : experiment.getAllocations()) {
                 println(
-                    "treatment: %s, offset: %d, size: %d",
-                    allocation.getTreatment().getName(),
-                    allocation.getOffset(),
-                    allocation.getSize()
-                );
+                        "treatment: %s, offset: %d, size: %d",
+                        allocation.getTreatment().getName(),
+                        allocation.getOffset(),
+                        allocation.getSize());
             }
             println();
 
@@ -110,21 +100,21 @@ public class LibraryExample {
 
             // You know what, who cares about pie or cake? Let's compare beer and wine!
             experiment
-                .clearTreatments()
-                .addTreatment("beer", "beer me!")
-                .addTreatment("wine", "wine please")
-                .allocate("beer", 90) // slightly biased
-                .allocate("wine", 10)
-                .save();
+                    .clearTreatments()
+                    .addTreatment("beer", "beer me!")
+                    .addTreatment("wine", "wine please")
+                    .allocate("beer", 90) // slightly biased
+                    .allocate("wine", 10)
+                    .save();
 
             // Ok, that was unfair, let's fix the allocations
             experiment
-                .deallocateAll()
-                .addOverride("gene_likes_beer", "beer", "user_name=gene")
-                .addOverride("qa_wine", "wine", "user_name=qa")
-                .allocate("beer", 51)
-                .allocate("wine", 49)
-                .save();
+                    .deallocateAll()
+                    .addOverride("gene_likes_beer", "beer", "user_name=gene")
+                    .addOverride("qa_wine", "wine", "user_name=qa")
+                    .allocate("beer", 51)
+                    .allocate("wine", 49)
+                    .save();
 
             // Print out an override
             final TreatmentOverride override = experiment.getOverride("qa_wine");
@@ -132,25 +122,25 @@ public class LibraryExample {
             println();
 
             // Let's query our active experiments
-            final Treatment activeTreatment = experiments.getActiveTreatment("my_experiment", new User("gene"));
-            println("name: %s, description: %s", activeTreatment.getName(), activeTreatment.getDescription());
+            final Treatment activeTreatment =
+                    experiments.getActiveTreatment("my_experiment", new User("gene"));
+            println(
+                    "name: %s, description: %s",
+                    activeTreatment.getName(), activeTreatment.getDescription());
             println();
 
-            for (final Map.Entry<Experiment, Treatment> entry : experiments.getActiveTreatments(new User("qa")).entrySet()) {
+            for (final Map.Entry<Experiment, Treatment> entry :
+                    experiments.getActiveTreatments(new User("qa")).entrySet()) {
                 println(
-                    "experiment: %s, treatment: %s, description: %s",
-                    entry.getKey().getName(),
-                    entry.getValue().getName(),
-                    entry.getValue().getDescription()
-                );
+                        "experiment: %s, treatment: %s, description: %s",
+                        entry.getKey().getName(),
+                        entry.getValue().getName(),
+                        entry.getValue().getDescription());
             }
             println();
 
             // Let's get rid of our overrides
-            experiment
-                .removeOverride("qa_wine")
-                .clearOverrides()
-                .save();
+            experiment.removeOverride("qa_wine").clearOverrides().save();
 
             println("number of overrides: %d", experiment.getOverrides().size());
             println();
@@ -161,49 +151,79 @@ public class LibraryExample {
             // Let's nuke it and call it a day
             experiments.delete("my_experiment");
 
-            // Experiment with composite identity - an identity where hashing can change based on what attributes are requested
+            // Experiment with composite identity - an identity where hashing can change based on
+            // what attributes are requested
             experiments
-                .create("composite")
-                 // we want only users that are identified and we prefer to hash on device
-                .setFilter(FilterExpression.of(String.format("%s & %s", User.ATTR_IDENTIFIED, Device.ATTR_DEVICE)))
-                .setHashAttributes(Device.ATTR_DEVICE)
-                .addTreatment("control")
-                .allocate("control", 100)
-                .activate()
-                .save();
+                    .create("composite")
+                    // we want only users that are identified and we prefer to hash on device
+                    .setFilter(
+                            FilterExpression.of(
+                                    String.format(
+                                            "%s & %s", User.ATTR_IDENTIFIED, Device.ATTR_DEVICE)))
+                    .setHashAttributes(Device.ATTR_DEVICE)
+                    .addTreatment("control")
+                    .allocate("control", 100)
+                    .activate()
+                    .save();
 
-            // These are the attributes that will be requested by the experiment when calling computeHash
-            final Set<String> hashAttributes = Sets.newLinkedHashSet(Lists.newArrayList(User.ATTR_IDENTIFIED, Device.ATTR_DEVICE));
+            // These are the attributes that will be requested by the experiment when calling
+            // computeHash
+            final Set<String> hashAttributes =
+                    Sets.newLinkedHashSet(
+                            Lists.newArrayList(User.ATTR_IDENTIFIED, Device.ATTR_DEVICE));
 
             final Composite userOnly = new Composite(new User("foo"), null);
-            println("treatment for user-only composite: %s", experiments.getActiveTreatment("composite", userOnly));
+            println(
+                    "treatment for user-only composite: %s",
+                    experiments.getActiveTreatment("composite", userOnly));
             println();
 
             final Composite deviceOnly = new Composite(null, new Device("bar"));
-            println("treatment for device-only composite: %s", experiments.getActiveTreatment("composite", deviceOnly));
+            println(
+                    "treatment for device-only composite: %s",
+                    experiments.getActiveTreatment("composite", deviceOnly));
             println();
 
             final Composite anonUser = new Composite(new User(null), new Device("bar"));
-            println("treatment for anon-user composite: %s", experiments.getActiveTreatment("composite", anonUser));
-            println("hash for anon-user composite: %d", anonUser.computeHash(0, hashAttributes, anonUser.computeAttributes()));
+            println(
+                    "treatment for anon-user composite: %s",
+                    experiments.getActiveTreatment("composite", anonUser));
+            println(
+                    "hash for anon-user composite: %d",
+                    anonUser.computeHash(0, hashAttributes, anonUser.computeAttributes()));
             println();
 
             final Composite userFoo = new Composite(new User("foo"), new Device("bar"));
-            println("treatment for user-foo composite: %s", experiments.getActiveTreatment("composite", userFoo));
-            println("hash for user-foo composite: %d", userFoo.computeHash(0, hashAttributes, userFoo.computeAttributes()));
+            println(
+                    "treatment for user-foo composite: %s",
+                    experiments.getActiveTreatment("composite", userFoo));
+            println(
+                    "hash for user-foo composite: %d",
+                    userFoo.computeHash(0, hashAttributes, userFoo.computeAttributes()));
             println();
 
-            // Since we're hashing on device, because that is our requested filter, hashes should be the same
+            // Since we're hashing on device, because that is our requested filter, hashes should be
+            // the same
             final Composite userBaz = new Composite(new User("baz"), new Device("bar"));
-            println("treatment for user-baz composite: %s", experiments.getActiveTreatment("composite", userBaz));
-            println("hash for user-baz composite: %d", userBaz.computeHash(0, hashAttributes, userBaz.computeAttributes()));
+            println(
+                    "treatment for user-baz composite: %s",
+                    experiments.getActiveTreatment("composite", userBaz));
+            println(
+                    "hash for user-baz composite: %d",
+                    userBaz.computeHash(0, hashAttributes, userBaz.computeAttributes()));
             println();
 
-            // Now change our attributes to not be specified to device, now hashes should be different
-            final Set<String> hashAttributes2 = Sets.newLinkedHashSet(Lists.newArrayList(User.ATTR_IDENTIFIED));
+            // Now change our attributes to not be specified to device, now hashes should be
+            // different
+            final Set<String> hashAttributes2 =
+                    Sets.newLinkedHashSet(Lists.newArrayList(User.ATTR_IDENTIFIED));
 
-            println("hash for user-foo composite: %d", userFoo.computeHash(0, hashAttributes2, userFoo.computeAttributes()));
-            println("hash for user-baz composite: %d", userBaz.computeHash(0, hashAttributes2, userBaz.computeAttributes()));
+            println(
+                    "hash for user-foo composite: %d",
+                    userFoo.computeHash(0, hashAttributes2, userFoo.computeAttributes()));
+            println(
+                    "hash for user-baz composite: %d",
+                    userBaz.computeHash(0, hashAttributes2, userBaz.computeAttributes()));
         }
     }
 }

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/ServiceExample.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/ServiceExample.java
@@ -3,11 +3,9 @@ package io.rtr.alchemy.example;
 import io.rtr.alchemy.service.AlchemyService;
 import io.rtr.alchemy.service.config.AlchemyServiceConfigurationImpl;
 
-/**
- * This example runs an instance of the Alchemy Dropwizard service with a basic configuration
- */
+/** This example runs an instance of the Alchemy Dropwizard service with a basic configuration */
 public class ServiceExample extends AlchemyService<AlchemyServiceConfigurationImpl> {
-    public static void main(String[] args) throws Exception{
+    public static void main(String[] args) throws Exception {
         new ServiceExample().run(args);
     }
 

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/config/MemoryStoreProvider.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/config/MemoryStoreProvider.java
@@ -3,9 +3,7 @@ package io.rtr.alchemy.example.config;
 import io.rtr.alchemy.db.ExperimentsStoreProvider;
 import io.rtr.alchemy.service.config.StoreProviderConfiguration;
 
-/**
- * Configuration object for creating an in-memory provider
- */
+/** Configuration object for creating an in-memory provider */
 public class MemoryStoreProvider extends StoreProviderConfiguration {
     @Override
     public ExperimentsStoreProvider createProvider() {

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/config/MongoStoreProvider.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/config/MongoStoreProvider.java
@@ -12,25 +12,22 @@ import javax.validation.constraints.NotNull;
 import java.net.UnknownHostException;
 import java.util.List;
 
-/**
- * Configuration object for creating a MongoDB provider with given parameters
- */
+/** Configuration object for creating a MongoDB provider with given parameters */
 public class MongoStoreProvider extends StoreProviderConfiguration {
-    @NotNull
-    private final List<HostAndPort> hosts;
+    @NotNull private final List<HostAndPort> hosts;
 
-    @NotNull
-    private final String db;
+    @NotNull private final String db;
 
     private final String username;
 
     private final String password;
 
     @JsonCreator
-    public MongoStoreProvider(@JsonProperty("hosts") List<HostAndPort> hosts,
-                              @JsonProperty("db") String db,
-                              @JsonProperty("username") String username,
-                              @JsonProperty("password") String password) {
+    public MongoStoreProvider(
+            @JsonProperty("hosts") List<HostAndPort> hosts,
+            @JsonProperty("db") String db,
+            @JsonProperty("username") String username,
+            @JsonProperty("password") String password) {
         this.hosts = hosts;
         this.db = db;
         this.username = username;
@@ -55,7 +52,8 @@ public class MongoStoreProvider extends StoreProviderConfiguration {
 
     @Override
     public ExperimentsStoreProvider createProvider() throws UnknownHostException {
-        final io.rtr.alchemy.db.mongo.MongoStoreProvider.Builder builder = io.rtr.alchemy.db.mongo.MongoStoreProvider.newBuilder();
+        final io.rtr.alchemy.db.mongo.MongoStoreProvider.Builder builder =
+                io.rtr.alchemy.db.mongo.MongoStoreProvider.newBuilder();
         for (final HostAndPort host : hosts) {
             if (!host.hasPort()) {
                 builder.addHost(new ServerAddress(host.getHost()));
@@ -65,7 +63,8 @@ public class MongoStoreProvider extends StoreProviderConfiguration {
         }
 
         if (username != null) {
-            builder.addCredential(MongoCredential.createPlainCredential(username, db, password.toCharArray()));
+            builder.addCredential(
+                    MongoCredential.createPlainCredential(username, db, password.toCharArray()));
         }
 
         builder.setDatabase(db);

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/config/PeriodicStaleCheckingCacheStrategy.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/config/PeriodicStaleCheckingCacheStrategy.java
@@ -8,9 +8,7 @@ import io.dropwizard.util.Duration;
 import javax.validation.constraints.NotNull;
 
 public class PeriodicStaleCheckingCacheStrategy extends CacheStrategyConfiguration {
-    @NotNull
-    @JsonProperty
-    private Duration duration;
+    @NotNull @JsonProperty private Duration duration;
 
     public Duration getDuration() {
         return duration;
@@ -18,6 +16,7 @@ public class PeriodicStaleCheckingCacheStrategy extends CacheStrategyConfigurati
 
     @Override
     public CacheStrategy createStrategy() {
-        return new io.rtr.alchemy.caching.PeriodicStaleCheckingCacheStrategy(org.joda.time.Duration.millis(duration.toMilliseconds()));
+        return new io.rtr.alchemy.caching.PeriodicStaleCheckingCacheStrategy(
+                org.joda.time.Duration.millis(duration.toMilliseconds()));
     }
 }

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/dto/UserDto.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/dto/UserDto.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.rtr.alchemy.dto.identities.IdentityDto;
 
-/**
- * An example DTO to be used for service payload
- */
+/** An example DTO to be used for service payload */
 @JsonTypeName("user")
 public class UserDto extends IdentityDto {
     private final String name;

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/identities/Composite.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/identities/Composite.java
@@ -7,10 +7,10 @@ import io.rtr.alchemy.identities.Identity;
 import java.util.Set;
 
 /**
- * Demonstrates how one may do composite identities, which are complex identities which are made up of sub-identities
- * and have complex criteria for computing their hash
+ * Demonstrates how one may do composite identities, which are complex identities which are made up
+ * of sub-identities and have complex criteria for computing their hash
  */
-@Attributes(identities = { User.class, Device.class })
+@Attributes(identities = {User.class, Device.class})
 public class Composite extends Identity {
     private final User user;
     private final Device device;
@@ -31,8 +31,10 @@ public class Composite extends Identity {
     @Override
     public long computeHash(int seed, Set<String> hashAttributes, AttributesMap attributes) {
         // we want to compute a hash based on what attribute is preferred (user vs device)
-        // we'll say that 'user' supersedes 'device', such that if only 'user' is specified, we hash user,
-        // if only device is specified, we hash device, if both are specified, we hash user.  If neither are
+        // we'll say that 'user' supersedes 'device', such that if only 'user' is specified, we hash
+        // user,
+        // if only device is specified, we hash device, if both are specified, we hash user.  If
+        // neither are
         // specified, we can return whichever is not null first user vs device
 
         if (hashAttributes.contains(User.ATTR_USER)) { // "user" or "both" were requested
@@ -41,7 +43,8 @@ public class Composite extends Identity {
             return device.computeHash(seed, hashAttributes, attributes);
         }
 
-        // neither was requested, default to whatever the most specifically identifying value we can return is
+        // neither was requested, default to whatever the most specifically identifying value we can
+        // return is
         if (user != null) {
             return user.computeHash(seed, hashAttributes, attributes);
         }
@@ -55,9 +58,6 @@ public class Composite extends Identity {
 
     @Override
     public AttributesMap computeAttributes() {
-        return attributes()
-            .put(user)
-            .put(device)
-            .build();
+        return attributes().put(user).put(device).build();
     }
 }

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/identities/Device.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/identities/Device.java
@@ -22,17 +22,11 @@ public class Device extends Identity {
 
     @Override
     public long computeHash(int seed, Set<String> hashAttributes, AttributesMap attributes) {
-        return
-            identity(seed)
-                .putString(id)
-                .hash();
+        return identity(seed).putString(id).hash();
     }
 
     @Override
     public AttributesMap computeAttributes() {
-        return attributes()
-            .put(ATTR_DEVICE, true)
-            .put(ATTR_DEVICE_ID, id)
-            .build();
+        return attributes().put(ATTR_DEVICE, true).put(ATTR_DEVICE_ID, id).build();
     }
 }

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/identities/User.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/identities/User.java
@@ -6,9 +6,7 @@ import io.rtr.alchemy.identities.Identity;
 
 import java.util.Set;
 
-/**
- * An example identity
- */
+/** An example identity */
 @Attributes({User.ATTR_USER, User.ATTR_ANONYMOUS, User.ATTR_IDENTIFIED, User.ATTR_USER_NAME})
 public class User extends Identity {
     public static final String ATTR_ANONYMOUS = "anonymous";
@@ -28,15 +26,12 @@ public class User extends Identity {
 
     @Override
     public long computeHash(int seed, Set<String> hashAttributes, AttributesMap attributes) {
-        return identity(seed)
-            .putString(name)
-            .hash();
+        return identity(seed).putString(name).hash();
     }
 
     @Override
     public AttributesMap computeAttributes() {
-        return
-            attributes()
+        return attributes()
                 .put(ATTR_USER, true)
                 .put(ATTR_USER_NAME, name)
                 .put(name == null ? ATTR_ANONYMOUS : ATTR_IDENTIFIED, true)

--- a/alchemy-example/src/main/java/io/rtr/alchemy/example/mappers/UserMapper.java
+++ b/alchemy-example/src/main/java/io/rtr/alchemy/example/mappers/UserMapper.java
@@ -4,9 +4,7 @@ import io.rtr.alchemy.example.dto.UserDto;
 import io.rtr.alchemy.example.identities.User;
 import io.rtr.alchemy.mapping.Mapper;
 
-/**
- * Maps to and from UserDto to User
- */
+/** Maps to and from UserDto to User */
 public class UserMapper implements Mapper<UserDto, User> {
     @Override
     public User fromDto(UserDto source) {

--- a/alchemy-mapping/src/main/java/io/rtr/alchemy/mapping/Mapper.java
+++ b/alchemy-mapping/src/main/java/io/rtr/alchemy/mapping/Mapper.java
@@ -1,9 +1,8 @@
 package io.rtr.alchemy.mapping;
 
-/**
- * Defines how to map an object to and from DTO and business object
- */
+/** Defines how to map an object to and from DTO and business object */
 public interface Mapper<TDto, TBo> {
     TDto toDto(TBo source);
+
     TBo fromDto(TDto source);
 }

--- a/alchemy-mapping/src/main/java/io/rtr/alchemy/mapping/Mappers.java
+++ b/alchemy-mapping/src/main/java/io/rtr/alchemy/mapping/Mappers.java
@@ -9,9 +9,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * The main class for registering mappers and doing mapping
- */
+/** The main class for registering mappers and doing mapping */
 public class Mappers {
     private final Map<Class<?>, Map<Class<?>, Mapper>> mappers = Maps.newConcurrentMap();
 
@@ -52,20 +50,12 @@ public class Mappers {
         }
 
         Preconditions.checkNotNull(
-            bySourceType,
-            "No mapper defined from type %s to type %s",
-            sourceType,
-            destType
-        );
+                bySourceType, "No mapper defined from type %s to type %s", sourceType, destType);
 
         final Mapper mapper = bySourceType.get(destType);
 
         Preconditions.checkArgument(
-            mapper != null,
-            "No mapper defined from type %s to type %s",
-            sourceType,
-            destType
-        );
+                mapper != null, "No mapper defined from type %s to type %s", sourceType, destType);
 
         return mapper;
     }

--- a/alchemy-mapping/src/test/java/io/rtr/alchemy/mapping/MappersTest.java
+++ b/alchemy-mapping/src/test/java/io/rtr/alchemy/mapping/MappersTest.java
@@ -6,27 +6,35 @@ import static org.junit.Assert.assertEquals;
 
 public class MappersTest {
 
-    private static interface DtoInterface { }
-    private static class ParentDto implements DtoInterface { }
-    private static class ChildDto extends ParentDto { }
-    private static interface BoInterface { }
-    private static class ParentBo implements BoInterface { }
-    private static class ChildBo extends ParentBo { }
+    private static interface DtoInterface {}
+
+    private static class ParentDto implements DtoInterface {}
+
+    private static class ChildDto extends ParentDto {}
+
+    private static interface BoInterface {}
+
+    private static class ParentBo implements BoInterface {}
+
+    private static class ChildBo extends ParentBo {}
 
     @Test
     public void testMapSubclassesAndInterfaces() {
         final Mappers mapper = new Mappers();
-        mapper.register(ChildDto.class, ChildBo.class, new Mapper() {
-            @Override
-            public Object toDto(Object source) {
-                return new ChildDto();
-            }
+        mapper.register(
+                ChildDto.class,
+                ChildBo.class,
+                new Mapper() {
+                    @Override
+                    public Object toDto(Object source) {
+                        return new ChildDto();
+                    }
 
-            @Override
-            public Object fromDto(Object source) {
-                return new ChildBo();
-            }
-        });
+                    @Override
+                    public Object fromDto(Object source) {
+                        return new ChildBo();
+                    }
+                });
 
         assertEquals(ChildBo.class, mapper.fromDto(new ChildDto(), ChildBo.class).getClass());
         assertEquals(ChildBo.class, mapper.fromDto(new ChildDto(), ParentBo.class).getClass());

--- a/alchemy-service/pom.xml
+++ b/alchemy-service/pom.xml
@@ -78,7 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
+        <version>${maven-shade-plugin.version}</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <filters>

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/AlchemyService.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/AlchemyService.java
@@ -22,10 +22,9 @@ import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
-/**
- * The entry point for the service
- */
-public abstract class AlchemyService<T extends Configuration & AlchemyServiceConfiguration> extends Application<T> {
+/** The entry point for the service */
+public abstract class AlchemyService<T extends Configuration & AlchemyServiceConfiguration>
+        extends Application<T> {
     private static final Class<?>[] RESOURCES = {
         ExperimentsResource.class,
         AllocationsResource.class,
@@ -55,12 +54,16 @@ public abstract class AlchemyService<T extends Configuration & AlchemyServiceCon
         registerIdentitySubTypes(configuration, environment);
     }
 
-    protected void runInjected(final Injector injector, final T configuration, final Environment environment) throws Exception {
+    protected void runInjected(
+            final Injector injector, final T configuration, final Environment environment)
+            throws Exception {
         for (final Class<?> resource : RESOURCES) {
             environment.jersey().register(injector.getInstance(resource));
         }
 
-        environment.healthChecks().register("database", injector.getInstance(ExperimentsDatabaseProviderCheck.class));
+        environment
+                .healthChecks()
+                .register("database", injector.getInstance(ExperimentsDatabaseProviderCheck.class));
     }
 
     private void registerIdentitySubTypes(T configuration, Environment environment) {

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/config/AlchemyServiceConfiguration.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/config/AlchemyServiceConfiguration.java
@@ -3,22 +3,14 @@ package io.rtr.alchemy.service.config;
 import io.rtr.alchemy.identities.Identity;
 import java.util.Map;
 
-/**
- * The base configuration for the Alchemy Dropwizard service
- */
+/** The base configuration for the Alchemy Dropwizard service */
 public interface AlchemyServiceConfiguration {
-    /**
-     * Defines a list of known identity types, which are used for assigning users to a treatment
-     */
+    /** Defines a list of known identity types, which are used for assigning users to a treatment */
     Map<Class<? extends Identity>, IdentityMapping> getIdentities();
 
-    /**
-     * Defines a store configuration for creating a store provider
-     */
+    /** Defines a store configuration for creating a store provider */
     StoreProviderConfiguration getProvider();
 
-    /**
-     * Defines a cache strategy configuration for creating a cache strategy
-     */
+    /** Defines a cache strategy configuration for creating a cache strategy */
     CacheStrategyConfiguration getCacheStrategy();
 }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/config/AlchemyServiceConfigurationImpl.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/config/AlchemyServiceConfigurationImpl.java
@@ -10,7 +10,8 @@ import io.dropwizard.Configuration;
 import javax.validation.constraints.NotNull;
 import java.util.Map;
 
-public class AlchemyServiceConfigurationImpl extends Configuration implements AlchemyServiceConfiguration {
+public class AlchemyServiceConfigurationImpl extends Configuration
+        implements AlchemyServiceConfiguration {
     @JsonProperty
     @JsonDeserialize(keyUsing = ClassKeyDeserializer.class)
     private final Map<Class<? extends Identity>, IdentityMapping> identities = Maps.newHashMap();
@@ -20,17 +21,14 @@ public class AlchemyServiceConfigurationImpl extends Configuration implements Al
         return identities;
     }
 
-    @JsonProperty
-    @NotNull
-    private final StoreProviderConfiguration provider = null;
+    @JsonProperty @NotNull private final StoreProviderConfiguration provider = null;
 
     @Override
     public StoreProviderConfiguration getProvider() {
         return provider;
     }
 
-    @JsonProperty
-    private final CacheStrategyConfiguration cacheStrategy = null;
+    @JsonProperty private final CacheStrategyConfiguration cacheStrategy = null;
 
     @Override
     public CacheStrategyConfiguration getCacheStrategy() {

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/config/CacheStrategyConfiguration.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/config/CacheStrategyConfiguration.java
@@ -3,9 +3,7 @@ package io.rtr.alchemy.service.config;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.rtr.alchemy.caching.CacheStrategy;
 
-/**
- * Base configuration object for creating a cache strategy
- */
+/** Base configuration object for creating a cache strategy */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public abstract class CacheStrategyConfiguration {
     public abstract CacheStrategy createStrategy();

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/config/IdentityMapping.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/config/IdentityMapping.java
@@ -5,16 +5,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.rtr.alchemy.dto.identities.IdentityDto;
 import io.rtr.alchemy.mapping.Mapper;
 
-/**
- * Represents a one-directional mapping of one type to another
- */
+/** Represents a one-directional mapping of one type to another */
 public class IdentityMapping {
     private final Class<? extends IdentityDto> dto;
     private final Class<? extends Mapper> mapper;
 
     @JsonCreator
-    public IdentityMapping(@JsonProperty("dto") Class<? extends IdentityDto> dto,
-                           @JsonProperty("mapper") Class<? extends Mapper> mapper) {
+    public IdentityMapping(
+            @JsonProperty("dto") Class<? extends IdentityDto> dto,
+            @JsonProperty("mapper") Class<? extends Mapper> mapper) {
         this.dto = dto;
         this.mapper = mapper;
     }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/config/StoreProviderConfiguration.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/config/StoreProviderConfiguration.java
@@ -3,9 +3,7 @@ package io.rtr.alchemy.service.config;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.rtr.alchemy.db.ExperimentsStoreProvider;
 
-/**
- * Base configuration object for creating store providers for experiments
- */
+/** Base configuration object for creating store providers for experiments */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public abstract class StoreProviderConfiguration {
     public abstract ExperimentsStoreProvider createProvider() throws Exception;

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/exceptions/RuntimeExceptionMapper.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/exceptions/RuntimeExceptionMapper.java
@@ -8,9 +8,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import java.util.Map;
 
-/**
- * Maps common runtime exceptions to their respective HTTP status codes
- */
+/** Maps common runtime exceptions to their respective HTTP status codes */
 public class RuntimeExceptionMapper implements ExceptionMapper<RuntimeException> {
     private static final Map<Class<?>, Response.Status> EXCEPTION_MAPPINGS;
 
@@ -18,13 +16,13 @@ public class RuntimeExceptionMapper implements ExceptionMapper<RuntimeException>
         EXCEPTION_MAPPINGS = Maps.newLinkedHashMap();
 
         // 400 - Bad Request
-        register(Response.Status.BAD_REQUEST,
-            IllegalArgumentException.class,
-            NullPointerException.class
-        );
+        register(
+                Response.Status.BAD_REQUEST,
+                IllegalArgumentException.class,
+                NullPointerException.class);
     }
 
-    private static void register(Response.Status status, Class<?> ... types) {
+    private static void register(Response.Status status, Class<?>... types) {
         for (Class<?> type : types) {
             EXCEPTION_MAPPINGS.put(type, status);
         }
@@ -42,8 +40,7 @@ public class RuntimeExceptionMapper implements ExceptionMapper<RuntimeException>
             throw new WebApplicationException(e);
         }
 
-        return Response
-                .status(status)
+        return Response.status(status)
                 .type(MediaType.APPLICATION_JSON)
                 .entity(e.getMessage())
                 .build();

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/filters/SparseFieldSetFilter.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/filters/SparseFieldSetFilter.java
@@ -1,6 +1,5 @@
 package io.rtr.alchemy.service.filters;
 
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -20,8 +19,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 /**
- * A filter to support returning partial results by specifying a 'fields' query parameter with a comma-separated list of
- * field names, or dot-delimited field names (for nested fields)
+ * A filter to support returning partial results by specifying a 'fields' query parameter with a
+ * comma-separated list of field names, or dot-delimited field names (for nested fields)
  */
 public class SparseFieldSetFilter implements ContainerResponseFilter {
     private static final Splitter SUB_FIELD_SPLITTER = Splitter.on(".");
@@ -63,7 +62,6 @@ public class SparseFieldSetFilter implements ContainerResponseFilter {
             }
         }
     }
-
 
     private static Set<String> expandFields(List<String> fieldsParam) {
         final Set<String> fields = Sets.newHashSet();

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/guice/AlchemyModule.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/guice/AlchemyModule.java
@@ -18,9 +18,7 @@ import io.dropwizard.setup.Environment;
 
 import java.util.Map.Entry;
 
-/**
- * Guice module for the service
- */
+/** Guice module for the service */
 public class AlchemyModule extends AbstractModule implements Managed {
     private final AlchemyServiceConfiguration configuration;
     private final Environment environment;
@@ -28,36 +26,35 @@ public class AlchemyModule extends AbstractModule implements Managed {
     private ExperimentsStoreProvider provider;
     private Experiments experiments;
 
-    public AlchemyModule(AlchemyServiceConfiguration configuration,
-                         Environment environment) {
+    public AlchemyModule(AlchemyServiceConfiguration configuration, Environment environment) {
         this.configuration = configuration;
         this.environment = environment;
 
         this.metadata = collectIdentityMetadata(configuration);
     }
 
-    private static IdentitiesMetadata collectIdentityMetadata(AlchemyServiceConfiguration configuration) {
+    private static IdentitiesMetadata collectIdentityMetadata(
+            AlchemyServiceConfiguration configuration) {
         final IdentitiesMetadata metadata = new IdentitiesMetadata();
 
-        for (final Entry<Class<? extends Identity>, IdentityMapping> entry : configuration.getIdentities().entrySet()) {
-            final JsonTypeName typeName = entry.getValue().getDtoType().getAnnotation(JsonTypeName.class);
+        for (final Entry<Class<? extends Identity>, IdentityMapping> entry :
+                configuration.getIdentities().entrySet()) {
+            final JsonTypeName typeName =
+                    entry.getValue().getDtoType().getAnnotation(JsonTypeName.class);
 
             Preconditions.checkNotNull(
-                typeName,
-                "identity DTO %s must specify @%s annotation",
-                entry.getValue().getDtoType().getSimpleName(),
-                JsonTypeName.class.getSimpleName()
-            );
+                    typeName,
+                    "identity DTO %s must specify @%s annotation",
+                    entry.getValue().getDtoType().getSimpleName(),
+                    JsonTypeName.class.getSimpleName());
 
             metadata.put(
-                typeName.value(),
-                new IdentityMetadata(
                     typeName.value(),
-                    entry.getKey(),
-                    entry.getValue().getDtoType(),
-                    entry.getValue().getMapperType()
-                )
-            );
+                    new IdentityMetadata(
+                            typeName.value(),
+                            entry.getKey(),
+                            entry.getValue().getDtoType(),
+                            entry.getValue().getMapperType()));
         }
 
         return metadata;
@@ -96,7 +93,8 @@ public class AlchemyModule extends AbstractModule implements Managed {
         final Mappers mappers = new Mappers();
 
         // identity types
-        for (final Entry<Class<? extends Identity>, IdentityMapping> mapping : configuration.getIdentities().entrySet()) {
+        for (final Entry<Class<? extends Identity>, IdentityMapping> mapping :
+                configuration.getIdentities().entrySet()) {
             final Mapper mapper = mapping.getValue().getMapperType().newInstance();
             mappers.register(mapping.getValue().getDtoType(), mapping.getKey(), mapper);
         }
@@ -107,8 +105,7 @@ public class AlchemyModule extends AbstractModule implements Managed {
     }
 
     @Override
-    public void start() throws Exception {
-    }
+    public void start() throws Exception {}
 
     @Override
     public void stop() throws Exception {

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/health/ExperimentsDatabaseProviderCheck.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/health/ExperimentsDatabaseProviderCheck.java
@@ -5,9 +5,7 @@ import com.google.inject.Inject;
 import io.rtr.alchemy.db.Filter;
 import io.rtr.alchemy.models.Experiments;
 
-/**
- * A health check that tests whether experiments can be read from the store
- */
+/** A health check that tests whether experiments can be read from the store */
 public class ExperimentsDatabaseProviderCheck extends HealthCheck {
     private final Experiments experiments;
 

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/jackson/ClassKeyDeserializer.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/jackson/ClassKeyDeserializer.java
@@ -5,12 +5,11 @@ import com.fasterxml.jackson.databind.KeyDeserializer;
 
 import java.io.IOException;
 
-/**
- * Allows Jackson to deserialize Map keys of type Class&lt;?&gt;
- */
+/** Allows Jackson to deserialize Map keys of type Class&lt;?&gt; */
 public class ClassKeyDeserializer extends KeyDeserializer {
     @Override
-    public Object deserializeKey(String className, DeserializationContext context) throws IOException {
+    public Object deserializeKey(String className, DeserializationContext context)
+            throws IOException {
         try {
             return Class.forName(className);
         } catch (ClassNotFoundException e) {

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/mapping/CoreMappings.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/mapping/CoreMappings.java
@@ -15,9 +15,7 @@ import io.rtr.alchemy.models.TreatmentOverride;
 
 import java.util.List;
 
-/**
- * A helper class for configuring the base required mappers for core domain objects
- */
+/** A helper class for configuring the base required mappers for core domain objects */
 public class CoreMappings {
 
     private static <T> List<T> safeArrayList(Iterable<T> iterable) {
@@ -27,89 +25,97 @@ public class CoreMappings {
     public static void configure(final Mappers mappers) {
         // fixed domain types
         mappers.register(
-            Treatment.class,
-            TreatmentDto.class,
-            new Mapper<TreatmentDto, Treatment>() {
-                @Override
-                public TreatmentDto toDto(Treatment treatment) {
-                    return new TreatmentDto(treatment.getName(), treatment.getDescription());
-                }
-
-                @Override
-                public Treatment fromDto(TreatmentDto dto) {
-                    throw new UnsupportedOperationException("mapping from dto not supported");
-                }
-            }
-        );
-
-        mappers.register(
-            Allocation.class,
-            AllocationDto.class,
-            new Mapper<AllocationDto, Allocation>() {
-                @Override
-                public AllocationDto toDto(Allocation allocation) {
-                    return new AllocationDto(allocation.getTreatment().getName(), allocation.getOffset(), allocation.getSize());
-                }
-
-                @Override
-                public Allocation fromDto(AllocationDto source) {
-                    throw new UnsupportedOperationException("mapping from dto not supported");
-                }
-            }
-        );
-
-        mappers.register(
-            TreatmentOverride.class,
-            TreatmentOverrideDto.class,
-            new Mapper<TreatmentOverrideDto, TreatmentOverride>() {
-                @Override
-                public TreatmentOverrideDto toDto(TreatmentOverride override) {
-                    return new TreatmentOverrideDto(
-                        override.getName(),
-                        override.getFilter().toString(),
-                        override.getTreatment().getName()
-                    );
-                }
-
-                @Override
-                public TreatmentOverride fromDto(TreatmentOverrideDto source) {
-                    throw new UnsupportedOperationException("mapping from dto not supported");
-                }
-            }
-        );
-
-        mappers.register(
-            Experiment.class,
-            ExperimentDto.class,
-            new Mapper<ExperimentDto, Experiment>() {
-                @Override
-                public ExperimentDto toDto(Experiment experiment) {
-                    if (experiment == null) {
-                        return null;
+                Treatment.class,
+                TreatmentDto.class,
+                new Mapper<TreatmentDto, Treatment>() {
+                    @Override
+                    public TreatmentDto toDto(Treatment treatment) {
+                        return new TreatmentDto(treatment.getName(), treatment.getDescription());
                     }
 
-                    return new ExperimentDto(
-                        experiment.getName(),
-                        experiment.getSeed(),
-                        experiment.getDescription(),
-                        experiment.getFilter() != null ? experiment.getFilter().toString() : null,
-                        experiment.getHashAttributes() != null ? Sets.newLinkedHashSet(experiment.getHashAttributes()) : null,
-                        experiment.isActive(),
-                        experiment.getCreated(),
-                        experiment.getModified(),
-                        experiment.getActivated(),
-                        experiment.getDeactivated(),
-                        safeArrayList(mappers.toDto(experiment.getTreatments(), TreatmentDto.class)),
-                        safeArrayList(mappers.toDto(experiment.getAllocations(), AllocationDto.class)),
-                        safeArrayList(mappers.toDto(experiment.getOverrides(), TreatmentOverrideDto.class))
-                    );
-                }
+                    @Override
+                    public Treatment fromDto(TreatmentDto dto) {
+                        throw new UnsupportedOperationException("mapping from dto not supported");
+                    }
+                });
 
-                @Override
-                public Experiment fromDto(ExperimentDto source) {
-                    throw new UnsupportedOperationException("mapping from dto not supported");
-                }
-            }
-        );
+        mappers.register(
+                Allocation.class,
+                AllocationDto.class,
+                new Mapper<AllocationDto, Allocation>() {
+                    @Override
+                    public AllocationDto toDto(Allocation allocation) {
+                        return new AllocationDto(
+                                allocation.getTreatment().getName(),
+                                allocation.getOffset(),
+                                allocation.getSize());
+                    }
+
+                    @Override
+                    public Allocation fromDto(AllocationDto source) {
+                        throw new UnsupportedOperationException("mapping from dto not supported");
+                    }
+                });
+
+        mappers.register(
+                TreatmentOverride.class,
+                TreatmentOverrideDto.class,
+                new Mapper<TreatmentOverrideDto, TreatmentOverride>() {
+                    @Override
+                    public TreatmentOverrideDto toDto(TreatmentOverride override) {
+                        return new TreatmentOverrideDto(
+                                override.getName(),
+                                override.getFilter().toString(),
+                                override.getTreatment().getName());
+                    }
+
+                    @Override
+                    public TreatmentOverride fromDto(TreatmentOverrideDto source) {
+                        throw new UnsupportedOperationException("mapping from dto not supported");
+                    }
+                });
+
+        mappers.register(
+                Experiment.class,
+                ExperimentDto.class,
+                new Mapper<ExperimentDto, Experiment>() {
+                    @Override
+                    public ExperimentDto toDto(Experiment experiment) {
+                        if (experiment == null) {
+                            return null;
+                        }
+
+                        return new ExperimentDto(
+                                experiment.getName(),
+                                experiment.getSeed(),
+                                experiment.getDescription(),
+                                experiment.getFilter() != null
+                                        ? experiment.getFilter().toString()
+                                        : null,
+                                experiment.getHashAttributes() != null
+                                        ? Sets.newLinkedHashSet(experiment.getHashAttributes())
+                                        : null,
+                                experiment.isActive(),
+                                experiment.getCreated(),
+                                experiment.getModified(),
+                                experiment.getActivated(),
+                                experiment.getDeactivated(),
+                                safeArrayList(
+                                        mappers.toDto(
+                                                experiment.getTreatments(), TreatmentDto.class)),
+                                safeArrayList(
+                                        mappers.toDto(
+                                                experiment.getAllocations(), AllocationDto.class)),
+                                safeArrayList(
+                                        mappers.toDto(
+                                                experiment.getOverrides(),
+                                                TreatmentOverrideDto.class)));
+                    }
+
+                    @Override
+                    public Experiment fromDto(ExperimentDto source) {
+                        throw new UnsupportedOperationException("mapping from dto not supported");
+                    }
+                });
     }
 }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/metadata/IdentitiesMetadata.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/metadata/IdentitiesMetadata.java
@@ -2,9 +2,7 @@ package io.rtr.alchemy.service.metadata;
 
 import java.util.LinkedHashMap;
 
-/**
- * A collection of meta data for identity types
- */
+/** A collection of meta data for identity types */
 public class IdentitiesMetadata extends LinkedHashMap<String, IdentityMetadata> {
     private static final long serialVersionUID = 7083352357635834895L;
 }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/metadata/IdentityMetadata.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/metadata/IdentityMetadata.java
@@ -6,9 +6,7 @@ import io.rtr.alchemy.mapping.Mapper;
 
 import java.util.Set;
 
-/**
- * Metadata for an identity type
- */
+/** Metadata for an identity type */
 public class IdentityMetadata {
     private final String typeName;
     private final Class<? extends Identity> identityType;
@@ -16,10 +14,11 @@ public class IdentityMetadata {
     private final Class<? extends Mapper> mapperType;
     private final Set<String> attributes;
 
-    public IdentityMetadata(String typeName,
-                            Class<? extends Identity> identityType,
-                            Class<? extends IdentityDto> dtoType,
-                            Class<? extends Mapper> mapperType) {
+    public IdentityMetadata(
+            String typeName,
+            Class<? extends Identity> identityType,
+            Class<? extends IdentityDto> dtoType,
+            Class<? extends Mapper> mapperType) {
         this.typeName = typeName;
         this.identityType = identityType;
         this.dtoType = dtoType;

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/metrics/JmxMetricsManaged.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/metrics/JmxMetricsManaged.java
@@ -4,9 +4,7 @@ import com.codahale.metrics.JmxReporter;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 
-/**
- * Enables logging of metrics to JMX
- */
+/** Enables logging of metrics to JMX */
 public class JmxMetricsManaged implements Managed {
     private final JmxReporter reporter;
 

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/ActiveTreatmentsResource.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/ActiveTreatmentsResource.java
@@ -20,9 +20,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
 
-/**
- * Resource for querying active experiments
- */
+/** Resource for querying active experiments */
 @Path("/active")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
@@ -39,15 +37,12 @@ public class ActiveTreatmentsResource extends BaseResource {
     @POST
     @Timed
     @Path("/experiments/{experimentName}/treatment")
-    public TreatmentDto getActiveTreatment(@PathParam("experimentName") String experimentName,
-                                           @Valid IdentityDto identity) {
+    public TreatmentDto getActiveTreatment(
+            @PathParam("experimentName") String experimentName, @Valid IdentityDto identity) {
         return mapper.toDto(
-            experiments.getActiveTreatment(
-                experimentName,
-                mapper.fromDto(identity, Identity.class)
-            ),
-            TreatmentDto.class
-        );
+                experiments.getActiveTreatment(
+                        experimentName, mapper.fromDto(identity, Identity.class)),
+                TreatmentDto.class);
     }
 
     @POST
@@ -55,12 +50,12 @@ public class ActiveTreatmentsResource extends BaseResource {
     @Path("/treatments")
     public Map<String, TreatmentDto> getActiveTreatments(@Valid IdentityDto identityDto) {
         final Map<String, TreatmentDto> treatments = Maps.newHashMap();
-        final Map<Experiment, Treatment> activeTreatments = experiments.getActiveTreatments(
-            mapper.fromDto(identityDto, Identity.class)
-        );
+        final Map<Experiment, Treatment> activeTreatments =
+                experiments.getActiveTreatments(mapper.fromDto(identityDto, Identity.class));
 
         for (final Map.Entry<Experiment, Treatment> entry : activeTreatments.entrySet()) {
-            treatments.put(entry.getKey().getName(), mapper.toDto(entry.getValue(), TreatmentDto.class));
+            treatments.put(
+                    entry.getKey().getName(), mapper.toDto(entry.getValue(), TreatmentDto.class));
         }
 
         return treatments;

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/AllocationsResource.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/AllocationsResource.java
@@ -32,24 +32,29 @@ public class AllocationsResource extends BaseResource {
     }
 
     @GET
-    public Iterable<AllocationDto> getAllocations(@PathParam("experimentName") String experimentName) {
+    public Iterable<AllocationDto> getAllocations(
+            @PathParam("experimentName") String experimentName) {
         return mapper.toDto(
-            ensureExists(experiments.get(experimentName)).getAllocations(),
-            AllocationDto.class
-        );
+                ensureExists(experiments.get(experimentName)).getAllocations(),
+                AllocationDto.class);
     }
 
     @POST
-    public void updateAllocations(@PathParam("experimentName") String experimentName,
-                                  @Valid List<AllocationRequest> requests) {
+    public void updateAllocations(
+            @PathParam("experimentName") String experimentName,
+            @Valid List<AllocationRequest> requests) {
         final Experiment experiment = ensureExists(experiments.get(experimentName));
 
         for (AllocationRequest request : requests) {
             if (request instanceof AllocationRequest.Deallocate) {
                 experiment.deallocate(request.getTreatment(), request.getSize());
             } else if (request instanceof AllocationRequest.Reallocate) {
-                final AllocationRequest.Reallocate reallocation = (AllocationRequest.Reallocate) request;
-                experiment.reallocate(reallocation.getTreatment(), reallocation.getTarget(), reallocation.getSize());
+                final AllocationRequest.Reallocate reallocation =
+                        (AllocationRequest.Reallocate) request;
+                experiment.reallocate(
+                        reallocation.getTreatment(),
+                        reallocation.getTarget(),
+                        reallocation.getSize());
             } else {
                 experiment.allocate(request.getTreatment(), request.getSize());
             }
@@ -60,8 +65,6 @@ public class AllocationsResource extends BaseResource {
 
     @DELETE
     public void clearAllocations(@PathParam("experimentName") String experimentName) {
-        ensureExists(experiments.get(experimentName))
-            .deallocateAll()
-            .save();
+        ensureExists(experiments.get(experimentName)).deallocateAll().save();
     }
 }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/BaseResource.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/BaseResource.java
@@ -3,11 +3,9 @@ package io.rtr.alchemy.service.resources;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
-/**
- * Base resource with various helper methods
- */
+/** Base resource with various helper methods */
 public abstract class BaseResource {
-    protected static  <T> T ensureExists(T value) {
+    protected static <T> T ensureExists(T value) {
         if (value == null) {
             throw new WebApplicationException(Response.Status.NOT_FOUND);
         }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/ExperimentsResource.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/ExperimentsResource.java
@@ -26,14 +26,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Set;
 
-/**
- * Resource for interacting with experiments
- */
+/** Resource for interacting with experiments */
 @Path("/experiments")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
@@ -48,22 +45,20 @@ public class ExperimentsResource extends BaseResource {
     }
 
     @GET
-    public Iterable<ExperimentDto> getExperiments(@QueryParam("filter") String filterValue,
-                                                  @QueryParam("offset") Integer offset,
-                                                  @QueryParam("limit") Integer limit,
-                                                  @QueryParam("sort") String sort) {
+    public Iterable<ExperimentDto> getExperiments(
+            @QueryParam("filter") String filterValue,
+            @QueryParam("offset") Integer offset,
+            @QueryParam("limit") Integer limit,
+            @QueryParam("sort") String sort) {
         return mapper.toDto(
-            experiments.find(
-                    Filter
-                        .criteria()
-                        .filter(filterValue)
-                        .offset(offset)
-                        .limit(limit)
-                        .ordering(Ordering.parse(sort))
-                        .build()
-            ),
-            ExperimentDto.class
-        );
+                experiments.find(
+                        Filter.criteria()
+                                .filter(filterValue)
+                                .offset(offset)
+                                .limit(limit)
+                                .ordering(Ordering.parse(sort))
+                                .build()),
+                ExperimentDto.class);
     }
 
     @PUT
@@ -73,9 +68,7 @@ public class ExperimentsResource extends BaseResource {
         }
 
         final Experiment experiment =
-            experiments
-                .create(request.getName())
-                .setDescription(request.getDescription());
+                experiments.create(request.getName()).setDescription(request.getDescription());
 
         if (request.getFilter() != null) {
             experiment.setFilter(FilterExpression.of(request.getFilter()));
@@ -103,7 +96,8 @@ public class ExperimentsResource extends BaseResource {
 
         if (request.getOverrides() != null) {
             for (final TreatmentOverrideRequest override : request.getOverrides()) {
-                experiment.addOverride(override.getName(), override.getTreatment(), override.getFilter());
+                experiment.addOverride(
+                        override.getName(), override.getTreatment(), override.getFilter());
             }
         }
 
@@ -122,8 +116,9 @@ public class ExperimentsResource extends BaseResource {
 
     @POST
     @Path("/{experimentName}")
-    public void updateExperiment(@PathParam("experimentName") String experimentName,
-                                 @Valid UpdateExperimentRequest request) {
+    public void updateExperiment(
+            @PathParam("experimentName") String experimentName,
+            @Valid UpdateExperimentRequest request) {
         final Experiment experiment = ensureExists(experiments.get(experimentName));
 
         if (request.getSeed() != null && request.getSeed().isPresent()) {
@@ -152,7 +147,8 @@ public class ExperimentsResource extends BaseResource {
             if (request.getTreatments().isPresent()) {
                 for (final TreatmentDto treatment : request.getTreatments().get()) {
                     missingTreatments.remove(treatment.getName());
-                    final Treatment existingTreatment = experiment.getTreatment(treatment.getName());
+                    final Treatment existingTreatment =
+                            experiment.getTreatment(treatment.getName());
 
                     if (existingTreatment != null) {
                         existingTreatment.setDescription(treatment.getDescription());
@@ -183,10 +179,7 @@ public class ExperimentsResource extends BaseResource {
             if (request.getOverrides().isPresent()) {
                 for (final TreatmentOverrideRequest override : request.getOverrides().get()) {
                     experiment.addOverride(
-                        override.getName(),
-                        override.getTreatment(),
-                        override.getFilter()
-                    );
+                            override.getName(), override.getTreatment(), override.getFilter());
                 }
             }
         }
@@ -205,16 +198,12 @@ public class ExperimentsResource extends BaseResource {
     @GET
     @Path("/{experimentName}")
     public ExperimentDto getExperiment(@PathParam("experimentName") String experimentName) {
-        return mapper.toDto(
-            ensureExists(experiments.get(experimentName)),
-            ExperimentDto.class
-        );
+        return mapper.toDto(ensureExists(experiments.get(experimentName)), ExperimentDto.class);
     }
 
     @DELETE
     @Path("/{experimentName}")
     public void removeExperiment(@PathParam("experimentName") String experimentName) {
-        ensureExists(experiments.get(experimentName))
-            .delete();
+        ensureExists(experiments.get(experimentName)).delete();
     }
 }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/MetadataResource.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/MetadataResource.java
@@ -24,9 +24,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Resource for retrieving registered identity types and their schemas
- */
+/** Resource for retrieving registered identity types and their schemas */
 @Path("/metadata")
 @Produces(MediaType.APPLICATION_JSON)
 public class MetadataResource extends BaseResource {
@@ -52,14 +50,16 @@ public class MetadataResource extends BaseResource {
 
     @GET
     @Path("/identityTypes/{identityType}/schema")
-    public JsonSchema getSchema(@PathParam("identityType") String identityType) throws JsonMappingException {
+    public JsonSchema getSchema(@PathParam("identityType") String identityType)
+            throws JsonMappingException {
         final Class<?> dtoType = ensureExists(identityTypesByName.get(identityType));
         return schemaGenerator.generateSchema(dtoType);
     }
 
     @GET
     @Path("/identityTypes/{identityType}/attributes")
-    public Set<String> getAttributes(@PathParam("identityType") String identityType) throws JsonMappingException {
+    public Set<String> getAttributes(@PathParam("identityType") String identityType)
+            throws JsonMappingException {
         final IdentityMetadata metadata = ensureExists(this.metadata.get(identityType));
         return metadata.getAttributes();
     }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/TreatmentOverridesResource.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/TreatmentOverridesResource.java
@@ -18,9 +18,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-/**
- * Resource for interacting with treatment overrides
- */
+/** Resource for interacting with treatment overrides */
 @Path("/experiments/{experimentName}/overrides")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
@@ -36,55 +34,46 @@ public class TreatmentOverridesResource extends BaseResource {
 
     @GET
     @Path("/{overrideName}")
-    public TreatmentOverrideDto getOverride(@PathParam("experimentName") String experimentName,
-                                            @PathParam("overrideName") String overrideName) {
+    public TreatmentOverrideDto getOverride(
+            @PathParam("experimentName") String experimentName,
+            @PathParam("overrideName") String overrideName) {
         return mapper.toDto(
-            ensureExists(
                 ensureExists(
-                    experiments.get(experimentName)
-                ).getOverride(overrideName)
-            ),
-            TreatmentOverrideDto.class
-        );
+                        ensureExists(experiments.get(experimentName)).getOverride(overrideName)),
+                TreatmentOverrideDto.class);
     }
 
     @GET
-    public Iterable<TreatmentOverrideDto> getOverrides(@PathParam("experimentName") String experimentName) {
+    public Iterable<TreatmentOverrideDto> getOverrides(
+            @PathParam("experimentName") String experimentName) {
         return mapper.toDto(
-            ensureExists(experiments.get(experimentName)).getOverrides(),
-            TreatmentOverrideDto.class
-        );
+                ensureExists(experiments.get(experimentName)).getOverrides(),
+                TreatmentOverrideDto.class);
     }
 
     @PUT
-    public Response addOverride(@PathParam("experimentName") String experimentName,
-                                @Valid TreatmentOverrideRequest request) {
+    public Response addOverride(
+            @PathParam("experimentName") String experimentName,
+            @Valid TreatmentOverrideRequest request) {
         ensureExists(experiments.get(experimentName))
-            .addOverride(
-                request.getName(),
-                request.getTreatment(),
-                request.getFilter()
-            )
-            .save();
+                .addOverride(request.getName(), request.getTreatment(), request.getFilter())
+                .save();
 
         return created();
     }
 
     @DELETE
     public void clearOverrides(@PathParam("experimentName") String experimentName) {
-        ensureExists(experiments.get(experimentName))
-            .clearOverrides()
-            .save();
+        ensureExists(experiments.get(experimentName)).clearOverrides().save();
     }
 
     @DELETE
     @Path("/{overrideName}")
-    public void removeOverride(@PathParam("experimentName") String experimentName,
-                               @PathParam("overrideName") String overrideName) {
+    public void removeOverride(
+            @PathParam("experimentName") String experimentName,
+            @PathParam("overrideName") String overrideName) {
         final Experiment experiment = ensureExists(experiments.get(experimentName));
         ensureExists(experiment.getOverride(overrideName));
-        experiment
-            .removeOverride(overrideName)
-            .save();
+        experiment.removeOverride(overrideName).save();
     }
 }

--- a/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/TreatmentsResource.java
+++ b/alchemy-service/src/main/java/io/rtr/alchemy/service/resources/TreatmentsResource.java
@@ -20,9 +20,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-/**
- * Resource for interacting with treatments
- */
+/** Resource for interacting with treatments */
 @Path("/experiments/{experimentName}/treatments")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
@@ -37,54 +35,53 @@ public class TreatmentsResource extends BaseResource {
     }
 
     @GET
-    public Iterable<TreatmentDto> getTreatments(@PathParam("experimentName") String experimentName) {
+    public Iterable<TreatmentDto> getTreatments(
+            @PathParam("experimentName") String experimentName) {
         return mapper.toDto(
-            ensureExists(experiments.get(experimentName)).getTreatments(),
-            TreatmentDto.class
-        );
+                ensureExists(experiments.get(experimentName)).getTreatments(), TreatmentDto.class);
     }
 
     @GET
     @Path("/{treatmentName}")
-    public TreatmentDto getTreatment(@PathParam("experimentName") String experimentName,
-                                     @PathParam("treatmentName") String treatmentName) {
+    public TreatmentDto getTreatment(
+            @PathParam("experimentName") String experimentName,
+            @PathParam("treatmentName") String treatmentName) {
         return mapper.toDto(
-            ensureExists(
-                ensureExists(experiments.get(experimentName)).getTreatment(treatmentName)
-            ),
-            TreatmentDto.class
-        );
+                ensureExists(
+                        ensureExists(experiments.get(experimentName)).getTreatment(treatmentName)),
+                TreatmentDto.class);
     }
 
     @PUT
-    public Response addTreatment(@PathParam("experimentName") String experimentName,
-                                 @Valid TreatmentDto treatmentDto) {
+    public Response addTreatment(
+            @PathParam("experimentName") String experimentName, @Valid TreatmentDto treatmentDto) {
         ensureExists(experiments.get(experimentName))
-            .addTreatment(treatmentDto.getName(), treatmentDto.getDescription())
-            .save();
+                .addTreatment(treatmentDto.getName(), treatmentDto.getDescription())
+                .save();
 
         return created();
     }
 
     @DELETE
     @Path("/{treatmentName}")
-    public void removeTreatment(@PathParam("experimentName") String experimentName,
-                                @PathParam("treatmentName") String treatmentName) {
+    public void removeTreatment(
+            @PathParam("experimentName") String experimentName,
+            @PathParam("treatmentName") String treatmentName) {
         final Experiment experiment = ensureExists(experiments.get(experimentName));
         ensureExists(experiment.getTreatment(treatmentName));
 
-        experiment
-            .removeTreatment(treatmentName)
-            .save();
+        experiment.removeTreatment(treatmentName).save();
     }
 
     @POST
     @Path("/{treatmentName}")
-    public void updateTreatment(@PathParam("experimentName") String experimentName,
-                                @PathParam("treatmentName") String treatmentName,
-                                @Valid UpdateTreatmentRequest request) {
+    public void updateTreatment(
+            @PathParam("experimentName") String experimentName,
+            @PathParam("treatmentName") String treatmentName,
+            @Valid UpdateTreatmentRequest request) {
         final Experiment experiment = ensureExists(experiments.get(experimentName));
-        final Treatment treatment = ensureExists(ensureExists(experiment).getTreatment(treatmentName));
+        final Treatment treatment =
+                ensureExists(ensureExists(experiment).getTreatment(treatmentName));
 
         if (request.getDescription() != null) {
             treatment.setDescription(request.getDescription().orElse(null));
@@ -95,8 +92,6 @@ public class TreatmentsResource extends BaseResource {
 
     @DELETE
     public void clearTreatments(@PathParam("experimentName") String experimentName) {
-        ensureExists(experiments.get(experimentName))
-            .clearTreatments()
-            .save();
+        ensureExists(experiments.get(experimentName)).clearTreatments().save();
     }
 }

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/filters/SparseFieldSetFilterTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/filters/SparseFieldSetFilterTest.java
@@ -44,7 +44,7 @@ public class SparseFieldSetFilterTest {
         doReturn(MediaType.APPLICATION_JSON_TYPE).when(response).getMediaType();
     }
 
-    private void doFilter(String ... fields) {
+    private void doFilter(String... fields) {
         final MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         queryParams.put("fields", Lists.newArrayList(fields));
         doReturn(queryParams).when(request).getHeaders();
@@ -63,10 +63,13 @@ public class SparseFieldSetFilterTest {
         entity.put("person", personNode);
 
         doReturn(entity).when(response).getEntity();
-        doAnswer(invocation -> {
-            responseEntity = (ObjectNode) invocation.getArguments()[0];
-            return null;
-        }).when(response).setEntity(any());
+        doAnswer(
+                        invocation -> {
+                            responseEntity = (ObjectNode) invocation.getArguments()[0];
+                            return null;
+                        })
+                .when(response)
+                .setEntity(any());
 
         filter.filter(request, response);
     }
@@ -124,5 +127,4 @@ public class SparseFieldSetFilterTest {
         assertEquals(personNode, arrayNode.get(0));
         assertTrue(personNode.has("name"));
     }
-
 }

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/ActiveTreatmentsResourceTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/ActiveTreatmentsResourceTest.java
@@ -12,7 +12,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 public class ActiveTreatmentsResourceTest extends ResourceTest {
-    private static final String ENDPOINT_ACTIVE_TREATMENT = "/active/experiments/{experimentName}/treatment";
+    private static final String ENDPOINT_ACTIVE_TREATMENT =
+            "/active/experiments/{experimentName}/treatment";
     private static final String ENDPOINT_ACTIVE_TREATMENTS = "/active/treatments";
     private UserDto userDto;
     private User user;
@@ -33,55 +34,65 @@ public class ActiveTreatmentsResourceTest extends ResourceTest {
     @Test
     public void testGetActiveTreatment() {
         post(ENDPOINT_ACTIVE_TREATMENT, EXPERIMENT_BAD)
-            .entity(userDto)
-            .assertStatus(Status.NO_CONTENT);
+                .entity(userDto)
+                .assertStatus(Status.NO_CONTENT);
 
-        final TreatmentDto expected1 = MAPPER.toDto(experiment(EXPERIMENT_1).getTreatment(user, user.computeAttributes()), TreatmentDto.class);
-        final TreatmentDto expected2 = MAPPER.toDto(experiment(EXPERIMENT_2).getTreatment(device, device.computeAttributes()), TreatmentDto.class);
+        final TreatmentDto expected1 =
+                MAPPER.toDto(
+                        experiment(EXPERIMENT_1).getTreatment(user, user.computeAttributes()),
+                        TreatmentDto.class);
+        final TreatmentDto expected2 =
+                MAPPER.toDto(
+                        experiment(EXPERIMENT_2).getTreatment(device, device.computeAttributes()),
+                        TreatmentDto.class);
 
         final TreatmentDto actual1 =
-            post(ENDPOINT_ACTIVE_TREATMENT, EXPERIMENT_1)
-                .entity(userDto)
-                .assertStatus(Status.OK)
-                .result(TreatmentDto.class);
+                post(ENDPOINT_ACTIVE_TREATMENT, EXPERIMENT_1)
+                        .entity(userDto)
+                        .assertStatus(Status.OK)
+                        .result(TreatmentDto.class);
 
         assertEquals(expected1, actual1);
 
         // wrong type
         post(ENDPOINT_ACTIVE_TREATMENT, EXPERIMENT_1)
-            .entity(deviceDto)
-            .assertStatus(Status.NO_CONTENT);
+                .entity(deviceDto)
+                .assertStatus(Status.NO_CONTENT);
 
         final TreatmentDto actual2 =
-            post(ENDPOINT_ACTIVE_TREATMENT, EXPERIMENT_2)
-                .entity(deviceDto)
-                .assertStatus(Status.OK)
-                .result(TreatmentDto.class);
+                post(ENDPOINT_ACTIVE_TREATMENT, EXPERIMENT_2)
+                        .entity(deviceDto)
+                        .assertStatus(Status.OK)
+                        .result(TreatmentDto.class);
 
         assertEquals(expected2, actual2);
 
         // not active
         post(ENDPOINT_ACTIVE_TREATMENT, EXPERIMENT_3)
-            .entity(userDto)
-            .assertStatus(Status.NO_CONTENT);
+                .entity(userDto)
+                .assertStatus(Status.NO_CONTENT);
 
         // not allocated
         post(ENDPOINT_ACTIVE_TREATMENT, EXPERIMENT_4)
-            .entity(userDto)
-            .assertStatus(Status.NO_CONTENT);
+                .entity(userDto)
+                .assertStatus(Status.NO_CONTENT);
     }
 
     @Test
     public void testGetActiveTreatments() {
-        final Map<String, TreatmentDto> expected = ImmutableMap.of(
-            EXPERIMENT_1, MAPPER.toDto(experiment(EXPERIMENT_1).getTreatment(user, user.computeAttributes()), TreatmentDto.class)
-        );
+        final Map<String, TreatmentDto> expected =
+                ImmutableMap.of(
+                        EXPERIMENT_1,
+                        MAPPER.toDto(
+                                experiment(EXPERIMENT_1)
+                                        .getTreatment(user, user.computeAttributes()),
+                                TreatmentDto.class));
 
         final Map<String, TreatmentDto> actual =
-            post(ENDPOINT_ACTIVE_TREATMENTS)
-                .entity(userDto)
-                .assertStatus(Status.OK)
-                .result(map(String.class, TreatmentDto.class));
+                post(ENDPOINT_ACTIVE_TREATMENTS)
+                        .entity(userDto)
+                        .assertStatus(Status.OK)
+                        .result(map(String.class, TreatmentDto.class));
 
         assertEquals(expected, actual);
     }

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/AllocationsResourceTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/AllocationsResourceTest.java
@@ -34,57 +34,53 @@ public class AllocationsResourceTest extends ResourceTest {
 
     @Test
     public void testGetAllocations() {
-        get(ALLOCATIONS_ENDPOINT, EXPERIMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        get(ALLOCATIONS_ENDPOINT, EXPERIMENT_BAD).assertStatus(Status.NOT_FOUND);
 
-        final Iterable<AllocationDto> expected = MAPPER.toDto(experiment(EXPERIMENT_1).getAllocations(), AllocationDto.class);
+        final Iterable<AllocationDto> expected =
+                MAPPER.toDto(experiment(EXPERIMENT_1).getAllocations(), AllocationDto.class);
         final Iterable<AllocationDto> actual =
-            get(ALLOCATIONS_ENDPOINT, EXPERIMENT_1)
-                .assertStatus(Status.OK)
-                .result(iterable(AllocationDto.class));
+                get(ALLOCATIONS_ENDPOINT, EXPERIMENT_1)
+                        .assertStatus(Status.OK)
+                        .result(iterable(AllocationDto.class));
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testUpdateAllocations() {
-        final AllocationRequests allocationRequest = AllocationRequests.of(
-            new AllocationRequest.Deallocate(EXP_1_TREATMENT_2, 10),
-            new AllocationRequest.Allocate(EXP_1_TREATMENT_1, 5),
-            new AllocationRequest.Reallocate(EXP_1_TREATMENT_3, 15, EXP_1_TREATMENT_1)
-        );
+        final AllocationRequests allocationRequest =
+                AllocationRequests.of(
+                        new AllocationRequest.Deallocate(EXP_1_TREATMENT_2, 10),
+                        new AllocationRequest.Allocate(EXP_1_TREATMENT_1, 5),
+                        new AllocationRequest.Reallocate(EXP_1_TREATMENT_3, 15, EXP_1_TREATMENT_1));
 
         post(ALLOCATIONS_ENDPOINT, EXPERIMENT_BAD)
-            .entity(allocationRequest)
-            .assertStatus(Status.NOT_FOUND);
+                .entity(allocationRequest)
+                .assertStatus(Status.NOT_FOUND);
 
-        final Map<String, Integer> allocations = ImmutableMap.of(
-            EXP_1_TREATMENT_1, 50,
-            EXP_1_TREATMENT_2, 25,
-            EXP_1_TREATMENT_3, 25
-        );
+        final Map<String, Integer> allocations =
+                ImmutableMap.of(
+                        EXP_1_TREATMENT_1, 50,
+                        EXP_1_TREATMENT_2, 25,
+                        EXP_1_TREATMENT_3, 25);
 
-        final Iterable<AllocationDto> currentAllocations = MAPPER.toDto(
-            experiment(EXPERIMENT_1).getAllocations(),
-            AllocationDto.class
-        );
+        final Iterable<AllocationDto> currentAllocations =
+                MAPPER.toDto(experiment(EXPERIMENT_1).getAllocations(), AllocationDto.class);
 
         assertEquals(allocations, countAllocations(currentAllocations));
 
         post(ALLOCATIONS_ENDPOINT, EXPERIMENT_1)
-            .entity(allocationRequest)
-            .assertStatus(Status.NO_CONTENT);
+                .entity(allocationRequest)
+                .assertStatus(Status.NO_CONTENT);
 
-        final Map<String, Integer> expectedAllocations = ImmutableMap.of(
-            EXP_1_TREATMENT_1, 75,
-            EXP_1_TREATMENT_2, 15,
-            EXP_1_TREATMENT_3, 10
-        );
+        final Map<String, Integer> expectedAllocations =
+                ImmutableMap.of(
+                        EXP_1_TREATMENT_1, 75,
+                        EXP_1_TREATMENT_2, 15,
+                        EXP_1_TREATMENT_3, 10);
 
-        final Iterable<AllocationDto> newAllocations = MAPPER.toDto(
-            experiment(EXPERIMENT_1).getAllocations(),
-            AllocationDto.class
-        );
+        final Iterable<AllocationDto> newAllocations =
+                MAPPER.toDto(experiment(EXPERIMENT_1).getAllocations(), AllocationDto.class);
 
         assertEquals(expectedAllocations, countAllocations(newAllocations));
     }

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/BaseResourceTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/BaseResourceTest.java
@@ -2,7 +2,6 @@ package io.rtr.alchemy.service.resources;
 
 import org.junit.Test;
 
-
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -19,7 +18,8 @@ public class BaseResourceTest {
     @Test
     public void testEnsureExists() {
         final Object value = new Object();
-        assertTrue("expected same object reference value", value == BaseResource.ensureExists(value));
+        assertTrue(
+                "expected same object reference value", value == BaseResource.ensureExists(value));
     }
 
     @Test(expected = WebApplicationException.class)

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/ExperimentsResourceTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/ExperimentsResourceTest.java
@@ -11,9 +11,7 @@ import io.rtr.alchemy.filtering.FilterExpression;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response.Status;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -25,24 +23,24 @@ public class ExperimentsResourceTest extends ResourceTest {
 
     @Test
     public void testGetExperiments() {
-        final Iterable<ExperimentDto> expected = MAPPER.toDto(EXPERIMENTS.find(), ExperimentDto.class);
+        final Iterable<ExperimentDto> expected =
+                MAPPER.toDto(EXPERIMENTS.find(), ExperimentDto.class);
         final Iterable<ExperimentDto> actual =
-            get(EXPERIMENTS_ENDPOINT)
-                .assertStatus(Status.OK)
-                .result(iterable(ExperimentDto.class));
+                get(EXPERIMENTS_ENDPOINT)
+                        .assertStatus(Status.OK)
+                        .result(iterable(ExperimentDto.class));
         assertEquals(expected, actual);
     }
 
     @Test
     public void testGetExperiment() {
-        get(EXPERIMENT_ENDPOINT, EXPERIMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        get(EXPERIMENT_ENDPOINT, EXPERIMENT_BAD).assertStatus(Status.NOT_FOUND);
 
         final ExperimentDto expected = MAPPER.toDto(experiment(EXPERIMENT_1), ExperimentDto.class);
         final ExperimentDto actual =
-            get(EXPERIMENT_ENDPOINT, EXPERIMENT_1)
-                .assertStatus(Status.OK)
-                .result(ExperimentDto.class);
+                get(EXPERIMENT_ENDPOINT, EXPERIMENT_1)
+                        .assertStatus(Status.OK)
+                        .result(ExperimentDto.class);
 
         assertEquals(expected, actual);
     }
@@ -50,30 +48,25 @@ public class ExperimentsResourceTest extends ResourceTest {
     @Test
     public void testAddExperiment() {
         final CreateExperimentRequest request =
-            new CreateExperimentRequest(
-                "new_experiment",
-                0,
-                "it's new",
-                null,
-                null,
-                false,
-                Lists.newArrayList(
-                    new TreatmentDto("control", "the default"),
-                    new TreatmentDto("first_case", "the first case"),
-                    new TreatmentDto("second_case", "the second case")
-                ),
-                Lists.newArrayList(
-                    new AllocateRequest("control", 10),
-                    new AllocateRequest("first_case", 20),
-                    new AllocateRequest("second_case", 30)
-                ),
-                Lists.<TreatmentOverrideRequest>newArrayList()
-            );
+                new CreateExperimentRequest(
+                        "new_experiment",
+                        0,
+                        "it's new",
+                        null,
+                        null,
+                        false,
+                        Lists.newArrayList(
+                                new TreatmentDto("control", "the default"),
+                                new TreatmentDto("first_case", "the first case"),
+                                new TreatmentDto("second_case", "the second case")),
+                        Lists.newArrayList(
+                                new AllocateRequest("control", 10),
+                                new AllocateRequest("first_case", 20),
+                                new AllocateRequest("second_case", 30)),
+                        Lists.<TreatmentOverrideRequest>newArrayList());
 
         assertNull(experiment("new_experiment"));
-        put(EXPERIMENTS_ENDPOINT)
-            .entity(request)
-            .assertStatus(Status.CREATED);
+        put(EXPERIMENTS_ENDPOINT).entity(request).assertStatus(Status.CREATED);
         assertNotNull(experiment("new_experiment"));
     }
 
@@ -89,54 +82,41 @@ public class ExperimentsResourceTest extends ResourceTest {
                         false,
                         Lists.newArrayList(
                                 new TreatmentDto("control", "the default"),
-                                new TreatmentDto("first_case", "the first case")
-                        ),
+                                new TreatmentDto("first_case", "the first case")),
                         Lists.newArrayList(
                                 new AllocateRequest("control", 50),
-                                new AllocateRequest("first_case", 50)
-                        ),
-                        Lists.<TreatmentOverrideRequest>newArrayList()
-                );
+                                new AllocateRequest("first_case", 50)),
+                        Lists.<TreatmentOverrideRequest>newArrayList());
 
-        put(EXPERIMENTS_ENDPOINT)
-                .entity(request)
-                .assertStatus(Status.CREATED);
+        put(EXPERIMENTS_ENDPOINT).entity(request).assertStatus(Status.CREATED);
         assertNotNull(experiment("duplicate_experiment_name"));
-        put(EXPERIMENTS_ENDPOINT)
-                .entity(request)
-                .assertStatus(Status.INTERNAL_SERVER_ERROR);
+        put(EXPERIMENTS_ENDPOINT).entity(request).assertStatus(Status.INTERNAL_SERVER_ERROR);
     }
 
     @Test
     public void testUpdateExperiment() {
         final UpdateExperimentRequest request =
-            new UpdateExperimentRequest(
-                Optional.empty(),
-                Optional.of("new description"),
-                Optional.of("device"),
-                Optional.empty(),
-                Optional.of(false),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty()
-            );
+                new UpdateExperimentRequest(
+                        Optional.empty(),
+                        Optional.of("new description"),
+                        Optional.of("device"),
+                        Optional.empty(),
+                        Optional.of(false),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty());
 
-        final ExperimentDto expected = MAPPER.toDto(
-                experiment(EXPERIMENT_1)
-                    .setDescription(request.getDescription().get())
-                    .setFilter(FilterExpression.of(request.getFilter().get()))
-                    .deactivate(),
-                ExperimentDto.class
-        );
+        final ExperimentDto expected =
+                MAPPER.toDto(
+                        experiment(EXPERIMENT_1)
+                                .setDescription(request.getDescription().get())
+                                .setFilter(FilterExpression.of(request.getFilter().get()))
+                                .deactivate(),
+                        ExperimentDto.class);
 
-        post(EXPERIMENT_ENDPOINT, EXPERIMENT_BAD)
-            .entity(request)
-            .assertStatus(Status.NOT_FOUND);
+        post(EXPERIMENT_ENDPOINT, EXPERIMENT_BAD).entity(request).assertStatus(Status.NOT_FOUND);
 
-
-        post(EXPERIMENT_ENDPOINT, EXPERIMENT_1)
-            .entity(request)
-            .assertStatus(Status.NO_CONTENT);
+        post(EXPERIMENT_ENDPOINT, EXPERIMENT_1).entity(request).assertStatus(Status.NO_CONTENT);
 
         final ExperimentDto actual = MAPPER.toDto(experiment(EXPERIMENT_1), ExperimentDto.class);
         assertEquals(expected, actual);
@@ -144,12 +124,10 @@ public class ExperimentsResourceTest extends ResourceTest {
 
     @Test
     public void testRemoveExperiment() {
-        delete(EXPERIMENT_ENDPOINT, EXPERIMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        delete(EXPERIMENT_ENDPOINT, EXPERIMENT_BAD).assertStatus(Status.NOT_FOUND);
 
         assertNotNull(EXPERIMENTS.get(EXPERIMENT_1));
-        delete(EXPERIMENT_ENDPOINT, EXPERIMENT_1)
-            .assertStatus(Status.NO_CONTENT);
+        delete(EXPERIMENT_ENDPOINT, EXPERIMENT_1).assertStatus(Status.NO_CONTENT);
         assertNull(EXPERIMENTS.get(EXPERIMENT_1));
     }
 }

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/MetadataResourceTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/MetadataResourceTest.java
@@ -14,8 +14,10 @@ import static org.junit.Assert.assertTrue;
 
 public class MetadataResourceTest extends ResourceTest {
     private static final String METADATA_IDENTITY_TYPES_ENDPOINT = "/metadata/identityTypes";
-    private static final String METADATA_IDENTITY_TYPE_SCHEMA_ENDPOINT = "/metadata/identityTypes/{identityType}/schema";
-    private static final String METADATA_IDENTITY_TYPE_ATTRIBUTES_ENDPOINT = "/metadata/identityTypes/{identityType}/attributes";
+    private static final String METADATA_IDENTITY_TYPE_SCHEMA_ENDPOINT =
+            "/metadata/identityTypes/{identityType}/schema";
+    private static final String METADATA_IDENTITY_TYPE_ATTRIBUTES_ENDPOINT =
+            "/metadata/identityTypes/{identityType}/attributes";
 
     @Test
     public void testGetIdentityTypes() {
@@ -24,45 +26,36 @@ public class MetadataResourceTest extends ResourceTest {
         expected.put("device", DeviceDto.class);
 
         final Map<String, Class> actual =
-            get(METADATA_IDENTITY_TYPES_ENDPOINT)
-                .assertStatus(Status.OK)
-                .result(map(String.class, Class.class));
+                get(METADATA_IDENTITY_TYPES_ENDPOINT)
+                        .assertStatus(Status.OK)
+                        .result(map(String.class, Class.class));
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testGetIdentitySchema() {
-        get(METADATA_IDENTITY_TYPE_SCHEMA_ENDPOINT, "foobar")
-            .assertStatus(Status.NOT_FOUND);
+        get(METADATA_IDENTITY_TYPE_SCHEMA_ENDPOINT, "foobar").assertStatus(Status.NOT_FOUND);
 
         final JsonSchema schema =
-            get(METADATA_IDENTITY_TYPE_SCHEMA_ENDPOINT, "user")
-                .assertStatus(Status.OK)
-                .result(JsonSchema.class);
+                get(METADATA_IDENTITY_TYPE_SCHEMA_ENDPOINT, "user")
+                        .assertStatus(Status.OK)
+                        .result(JsonSchema.class);
 
         assertNotNull(schema);
-        assertTrue(
-            schema
-                .asObjectSchema()
-                .getProperties()
-                .get("name")
-                .isStringSchema()
-        );
+        assertTrue(schema.asObjectSchema().getProperties().get("name").isStringSchema());
     }
 
     @Test
     public void testGetIdentityAttributes() {
-        get(METADATA_IDENTITY_TYPE_ATTRIBUTES_ENDPOINT, "foobar")
-            .assertStatus(Status.NOT_FOUND);
+        get(METADATA_IDENTITY_TYPE_ATTRIBUTES_ENDPOINT, "foobar").assertStatus(Status.NOT_FOUND);
 
         final Iterable<String> attributes =
-            get(METADATA_IDENTITY_TYPE_ATTRIBUTES_ENDPOINT, "user")
-                .assertStatus(Status.OK)
-                .result(set(String.class));
+                get(METADATA_IDENTITY_TYPE_ATTRIBUTES_ENDPOINT, "user")
+                        .assertStatus(Status.OK)
+                        .result(set(String.class));
 
         assertNotNull(attributes);
         assertEquals(Sets.newHashSet("anonymous", "identified"), attributes);
-
     }
 }

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/ResourceTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/ResourceTest.java
@@ -73,8 +73,7 @@ public abstract class ResourceTest {
     protected static final String ATTR_DEVICE = "device";
     protected final List<Response> openResponses = Lists.newArrayList();
 
-    @ClassRule
-    public static final ResourceTestRule RESOURCES;
+    @ClassRule public static final ResourceTestRule RESOURCES;
 
     static {
         PROVIDER = new MemoryStoreProvider();
@@ -88,20 +87,22 @@ public abstract class ResourceTest {
         final Environment environment = mock(Environment.class);
         doReturn(mapper).when(environment).getObjectMapper();
         final IdentitiesMetadata metadata = new IdentitiesMetadata();
-        metadata.put("user", new IdentityMetadata("user", User.class, UserDto.class, UserMapper.class));
-        metadata.put("device", new IdentityMetadata("device", Device.class, DeviceDto.class, DeviceMapper.class));
+        metadata.put(
+                "user", new IdentityMetadata("user", User.class, UserDto.class, UserMapper.class));
+        metadata.put(
+                "device",
+                new IdentityMetadata("device", Device.class, DeviceDto.class, DeviceMapper.class));
 
         RESOURCES =
-            ResourceTestRule
-                .builder()
-                .setMapper(mapper)
-                .addResource(new TreatmentsResource(EXPERIMENTS, MAPPER))
-                .addResource(new AllocationsResource(EXPERIMENTS, MAPPER))
-                .addResource(new TreatmentOverridesResource(EXPERIMENTS, MAPPER))
-                .addResource(new ExperimentsResource(EXPERIMENTS, MAPPER))
-                .addResource(new ActiveTreatmentsResource(EXPERIMENTS, MAPPER))
-                .addResource(new MetadataResource(environment, metadata, MAPPER))
-                .build();
+                ResourceTestRule.builder()
+                        .setMapper(mapper)
+                        .addResource(new TreatmentsResource(EXPERIMENTS, MAPPER))
+                        .addResource(new AllocationsResource(EXPERIMENTS, MAPPER))
+                        .addResource(new TreatmentOverridesResource(EXPERIMENTS, MAPPER))
+                        .addResource(new ExperimentsResource(EXPERIMENTS, MAPPER))
+                        .addResource(new ActiveTreatmentsResource(EXPERIMENTS, MAPPER))
+                        .addResource(new MetadataResource(environment, metadata, MAPPER))
+                        .build();
     }
 
     @Before
@@ -109,42 +110,38 @@ public abstract class ResourceTest {
         PROVIDER.resetDatabase();
 
         EXPERIMENTS
-            .create(EXPERIMENT_1)
-            .setDescription("do people want pie or cake?")
-            .activate()
-            .setFilter(FilterExpression.of(ATTR_IDENTIFIED))
-            .addTreatment(EXP_1_TREATMENT_1)
-            .addTreatment(EXP_1_TREATMENT_2)
-            .addTreatment(EXP_1_TREATMENT_3)
-            .allocate(EXP_1_TREATMENT_1, 50)
-            .allocate(EXP_1_TREATMENT_2, 25)
-            .allocate(EXP_1_TREATMENT_3, 25)
-            .addOverride(EXP_1_OVERRIDE, EXP_1_TREATMENT_2, EXP_1_OVERRIDE_USER)
-            .save();
+                .create(EXPERIMENT_1)
+                .setDescription("do people want pie or cake?")
+                .activate()
+                .setFilter(FilterExpression.of(ATTR_IDENTIFIED))
+                .addTreatment(EXP_1_TREATMENT_1)
+                .addTreatment(EXP_1_TREATMENT_2)
+                .addTreatment(EXP_1_TREATMENT_3)
+                .allocate(EXP_1_TREATMENT_1, 50)
+                .allocate(EXP_1_TREATMENT_2, 25)
+                .allocate(EXP_1_TREATMENT_3, 25)
+                .addOverride(EXP_1_OVERRIDE, EXP_1_TREATMENT_2, EXP_1_OVERRIDE_USER)
+                .save();
 
         EXPERIMENTS
-            .create(EXPERIMENT_2)
-            .activate()
-            .setFilter(FilterExpression.of(ATTR_DEVICE))
-            .addTreatment(EXP_2_TREATMENT_1)
-            .addTreatment(EXP_2_TREATMENT_2)
-            .addTreatment(EXP_2_TREATMENT_3)
-            .allocate(EXP_2_TREATMENT_1, 50)
-            .allocate(EXP_2_TREATMENT_2, 25)
-            .allocate(EXP_2_TREATMENT_3, 25)
-            .save();
+                .create(EXPERIMENT_2)
+                .activate()
+                .setFilter(FilterExpression.of(ATTR_DEVICE))
+                .addTreatment(EXP_2_TREATMENT_1)
+                .addTreatment(EXP_2_TREATMENT_2)
+                .addTreatment(EXP_2_TREATMENT_3)
+                .allocate(EXP_2_TREATMENT_1, 50)
+                .allocate(EXP_2_TREATMENT_2, 25)
+                .allocate(EXP_2_TREATMENT_3, 25)
+                .save();
 
         EXPERIMENTS
-            .create(EXPERIMENT_3)
-            .addTreatment(EXP_3_TREATMENT_1)
-            .allocate(EXP_3_TREATMENT_1, 100)
-            .save();
+                .create(EXPERIMENT_3)
+                .addTreatment(EXP_3_TREATMENT_1)
+                .allocate(EXP_3_TREATMENT_1, 100)
+                .save();
 
-        EXPERIMENTS
-            .create(EXPERIMENT_4)
-            .addTreatment(EXP_4_TREATMENT_1)
-            .activate()
-            .save();
+        EXPERIMENTS.create(EXPERIMENT_4).addTreatment(EXP_4_TREATMENT_1).activate().save();
     }
 
     @After
@@ -183,10 +180,10 @@ public abstract class ResourceTest {
         }
 
         return RESOURCES
-            .client()
-            .target(substUrl)
-            .request()
-            .accept(MediaType.APPLICATION_JSON_TYPE);
+                .client()
+                .target(substUrl)
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE);
     }
 
     protected static Experiment experiment(String name) {
@@ -212,10 +209,9 @@ public abstract class ResourceTest {
 
         @Override
         public AttributesMap computeAttributes() {
-            return
-                    name == null ?
-                    attributes().put("anonymous", true).build() :
-                    attributes().put("identified", true).build();
+            return name == null
+                    ? attributes().put("anonymous", true).build()
+                    : attributes().put("identified", true).build();
         }
     }
 
@@ -305,7 +301,7 @@ public abstract class ResourceTest {
         return new ResourceAssertionBuilder(SyncInvoker::put, resource(url, pathParams));
     }
 
-    protected ResourceAssertionBuilder post(String url, String ... pathParams) {
+    protected ResourceAssertionBuilder post(String url, String... pathParams) {
         return new ResourceAssertionBuilder(SyncInvoker::post, resource(url, pathParams));
     }
 
@@ -317,14 +313,16 @@ public abstract class ResourceTest {
         private final BiFunction<Invocation.Builder, Entity, Response> action;
         private final Invocation.Builder resource;
 
-        public ResourceAssertionBuilder(BiFunction<Invocation.Builder, Entity, Response> action,
-                                        Invocation.Builder resource) {
+        public ResourceAssertionBuilder(
+                BiFunction<Invocation.Builder, Entity, Response> action,
+                Invocation.Builder resource) {
             this.action = action;
             this.resource = resource;
         }
 
         public ResourceAssertion entity(Object entity) {
-            final Response response = action.apply(resource, Entity.entity(entity, MediaType.APPLICATION_JSON_TYPE));
+            final Response response =
+                    action.apply(resource, Entity.entity(entity, MediaType.APPLICATION_JSON_TYPE));
             openResponses.add(response);
             return new ResourceAssertion(response);
         }
@@ -338,7 +336,8 @@ public abstract class ResourceTest {
         }
 
         public ResourceAssertion assertStatus(Response.Status expectedStatus) {
-            assertEquals("status did not match", expectedStatus.getStatusCode(), response.getStatus());
+            assertEquals(
+                    "status did not match", expectedStatus.getStatusCode(), response.getStatus());
             return this;
         }
 

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/TreatmentOverridesResourceTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/TreatmentOverridesResourceTest.java
@@ -12,95 +12,81 @@ import static org.junit.Assert.assertNull;
 
 public class TreatmentOverridesResourceTest extends ResourceTest {
     private static final String ENDPOINT_OVERRIDES = "/experiments/{experimentName}/overrides";
-    private static final String ENDPOINT_OVERRIDE = "/experiments/{experimentName}/overrides/{overrideName}";
+    private static final String ENDPOINT_OVERRIDE =
+            "/experiments/{experimentName}/overrides/{overrideName}";
 
     @Test
     public void testGetOverrides() {
-        get(ENDPOINT_OVERRIDES, EXPERIMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        get(ENDPOINT_OVERRIDES, EXPERIMENT_BAD).assertStatus(Status.NOT_FOUND);
 
-        final Iterable<TreatmentOverrideDto> expected = MAPPER.toDto(
-            experiment(EXPERIMENT_1).getOverrides(),
-            TreatmentOverrideDto.class
-        );
+        final Iterable<TreatmentOverrideDto> expected =
+                MAPPER.toDto(experiment(EXPERIMENT_1).getOverrides(), TreatmentOverrideDto.class);
 
         final Iterable<TreatmentOverrideDto> actual =
-            get(ENDPOINT_OVERRIDES, EXPERIMENT_1)
-                .assertStatus(Status.OK)
-                .result(iterable(TreatmentOverrideDto.class));
+                get(ENDPOINT_OVERRIDES, EXPERIMENT_1)
+                        .assertStatus(Status.OK)
+                        .result(iterable(TreatmentOverrideDto.class));
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testGetOverride() {
-        get(ENDPOINT_OVERRIDE, EXPERIMENT_BAD, EXP_1_OVERRIDE)
-            .assertStatus(Status.NOT_FOUND);
+        get(ENDPOINT_OVERRIDE, EXPERIMENT_BAD, EXP_1_OVERRIDE).assertStatus(Status.NOT_FOUND);
 
-        get(ENDPOINT_OVERRIDE, EXPERIMENT_1, OVERRIDE_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        get(ENDPOINT_OVERRIDE, EXPERIMENT_1, OVERRIDE_BAD).assertStatus(Status.NOT_FOUND);
 
-        final TreatmentOverrideDto expected = MAPPER.toDto(
-            experiment(EXPERIMENT_1).getOverride(EXP_1_OVERRIDE),
-            TreatmentOverrideDto.class
-        );
+        final TreatmentOverrideDto expected =
+                MAPPER.toDto(
+                        experiment(EXPERIMENT_1).getOverride(EXP_1_OVERRIDE),
+                        TreatmentOverrideDto.class);
 
         final TreatmentOverrideDto actual =
-            get(ENDPOINT_OVERRIDE, EXPERIMENT_1, EXP_1_OVERRIDE)
-                .assertStatus(Status.OK)
-                .result(TreatmentOverrideDto.class);
+                get(ENDPOINT_OVERRIDE, EXPERIMENT_1, EXP_1_OVERRIDE)
+                        .assertStatus(Status.OK)
+                        .result(TreatmentOverrideDto.class);
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testAddOverride() {
-        final TreatmentOverrideRequest request = new TreatmentOverrideRequest("control", "qa", "qa_control");
+        final TreatmentOverrideRequest request =
+                new TreatmentOverrideRequest("control", "qa", "qa_control");
 
-        put(ENDPOINT_OVERRIDES, EXPERIMENT_BAD)
-            .entity(request)
-            .assertStatus(Status.NOT_FOUND);
+        put(ENDPOINT_OVERRIDES, EXPERIMENT_BAD).entity(request).assertStatus(Status.NOT_FOUND);
 
-        final TreatmentOverrideDto expected = new TreatmentOverrideDto(
-            request.getName(),
-            request.getFilter(),
-            request.getTreatment()
-        );
+        final TreatmentOverrideDto expected =
+                new TreatmentOverrideDto(
+                        request.getName(), request.getFilter(), request.getTreatment());
 
-        put(ENDPOINT_OVERRIDES, EXPERIMENT_1)
-            .entity(request)
-            .assertStatus(Status.CREATED);
+        put(ENDPOINT_OVERRIDES, EXPERIMENT_1).entity(request).assertStatus(Status.CREATED);
 
-        final TreatmentOverrideDto actual = MAPPER.toDto(
-            experiment(EXPERIMENT_1).getOverride(request.getName()),
-            TreatmentOverrideDto.class
-        );
+        final TreatmentOverrideDto actual =
+                MAPPER.toDto(
+                        experiment(EXPERIMENT_1).getOverride(request.getName()),
+                        TreatmentOverrideDto.class);
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testRemoveOverride() {
-        delete(ENDPOINT_OVERRIDE, EXPERIMENT_BAD, EXP_1_OVERRIDE)
-            .assertStatus(Status.NOT_FOUND);
+        delete(ENDPOINT_OVERRIDE, EXPERIMENT_BAD, EXP_1_OVERRIDE).assertStatus(Status.NOT_FOUND);
 
-        delete(ENDPOINT_OVERRIDE, EXPERIMENT_1, OVERRIDE_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        delete(ENDPOINT_OVERRIDE, EXPERIMENT_1, OVERRIDE_BAD).assertStatus(Status.NOT_FOUND);
 
         assertNotNull(experiment(EXPERIMENT_1).getOverride(EXP_1_OVERRIDE));
-        delete(ENDPOINT_OVERRIDE, EXPERIMENT_1, EXP_1_OVERRIDE)
-            .assertStatus(Status.NO_CONTENT);
+        delete(ENDPOINT_OVERRIDE, EXPERIMENT_1, EXP_1_OVERRIDE).assertStatus(Status.NO_CONTENT);
         assertNull(experiment(EXPERIMENT_1).getOverride(EXP_1_OVERRIDE));
     }
 
     @Test
     public void testClearOverrides() {
-        delete(ENDPOINT_OVERRIDES, EXPERIMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        delete(ENDPOINT_OVERRIDES, EXPERIMENT_BAD).assertStatus(Status.NOT_FOUND);
 
         assertNotNull(experiment(EXPERIMENT_1).getOverride(EXP_1_OVERRIDE));
-        delete(ENDPOINT_OVERRIDES, EXPERIMENT_1)
-            .assertStatus(Status.NO_CONTENT);
+        delete(ENDPOINT_OVERRIDES, EXPERIMENT_1).assertStatus(Status.NO_CONTENT);
         assertNull(experiment(EXPERIMENT_1).getOverride(EXP_1_OVERRIDE));
     }
 }

--- a/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/TreatmentsResourceTest.java
+++ b/alchemy-service/src/test/java/io/rtr/alchemy/service/resources/TreatmentsResourceTest.java
@@ -17,36 +17,38 @@ import static org.junit.Assert.assertNull;
 
 public class TreatmentsResourceTest extends ResourceTest {
     private static final String TREATMENTS_ENDPOINT = "/experiments/{experimentName}/treatments";
-    private static final String TREATMENT_ENDPOINT = "/experiments/{experimentName}/treatments/{treatment}";
+    private static final String TREATMENT_ENDPOINT =
+            "/experiments/{experimentName}/treatments/{treatment}";
     private static final String ALLOCATIONS_ENDPOINT = "/experiments/{experimentName}/allocations";
 
     @Test
     public void testGetTreatments() {
-        get(TREATMENTS_ENDPOINT, EXPERIMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        get(TREATMENTS_ENDPOINT, EXPERIMENT_BAD).assertStatus(Status.NOT_FOUND);
 
-        final Iterable<TreatmentDto> expected = MAPPER.toDto(experiment(EXPERIMENT_1).getTreatments(), TreatmentDto.class);
+        final Iterable<TreatmentDto> expected =
+                MAPPER.toDto(experiment(EXPERIMENT_1).getTreatments(), TreatmentDto.class);
         final Iterable<TreatmentDto> actual =
-            get(TREATMENTS_ENDPOINT, EXPERIMENT_1)
-                .assertStatus(Status.OK)
-                .result(iterable(TreatmentDto.class));
+                get(TREATMENTS_ENDPOINT, EXPERIMENT_1)
+                        .assertStatus(Status.OK)
+                        .result(iterable(TreatmentDto.class));
 
         assertEquals(expected, actual);
     }
 
     @Test
     public void testGetTreatment() {
-        get(TREATMENT_ENDPOINT, EXPERIMENT_BAD, EXP_1_TREATMENT_1)
-            .assertStatus(Status.NOT_FOUND);
+        get(TREATMENT_ENDPOINT, EXPERIMENT_BAD, EXP_1_TREATMENT_1).assertStatus(Status.NOT_FOUND);
 
-        get(TREATMENT_ENDPOINT, EXPERIMENT_1, TREATMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        get(TREATMENT_ENDPOINT, EXPERIMENT_1, TREATMENT_BAD).assertStatus(Status.NOT_FOUND);
 
-        final TreatmentDto expected = MAPPER.toDto(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_1), TreatmentDto.class);
+        final TreatmentDto expected =
+                MAPPER.toDto(
+                        experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_1),
+                        TreatmentDto.class);
         final TreatmentDto actual =
-            get(TREATMENT_ENDPOINT, EXPERIMENT_1, EXP_1_TREATMENT_1)
-                .assertStatus(Status.OK)
-                .result(TreatmentDto.class);
+                get(TREATMENT_ENDPOINT, EXPERIMENT_1, EXP_1_TREATMENT_1)
+                        .assertStatus(Status.OK)
+                        .result(TreatmentDto.class);
 
         assertEquals(expected, actual);
     }
@@ -55,83 +57,81 @@ public class TreatmentsResourceTest extends ResourceTest {
     public void testAddTreatment() {
         final TreatmentDto expected = new TreatmentDto("new_treatment", "this is a new treatment");
 
-        put(TREATMENTS_ENDPOINT, EXPERIMENT_BAD)
-            .entity(expected)
-            .assertStatus(Status.NOT_FOUND);
+        put(TREATMENTS_ENDPOINT, EXPERIMENT_BAD).entity(expected).assertStatus(Status.NOT_FOUND);
 
-        put(TREATMENTS_ENDPOINT, EXPERIMENT_1)
-            .entity(expected)
-            .assertStatus(Status.CREATED);
+        put(TREATMENTS_ENDPOINT, EXPERIMENT_1).entity(expected).assertStatus(Status.CREATED);
 
-        final TreatmentDto actual = MAPPER.toDto(experiment(EXPERIMENT_1).getTreatment(expected.getName()), TreatmentDto.class);
+        final TreatmentDto actual =
+                MAPPER.toDto(
+                        experiment(EXPERIMENT_1).getTreatment(expected.getName()),
+                        TreatmentDto.class);
         assertEquals(expected, actual);
     }
 
     @Test
     public void testRemoveTreamtment() {
         delete(TREATMENT_ENDPOINT, EXPERIMENT_BAD, EXP_1_TREATMENT_1)
-            .assertStatus(Status.NOT_FOUND);
+                .assertStatus(Status.NOT_FOUND);
 
-        delete(TREATMENT_ENDPOINT, EXPERIMENT_1, TREATMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        delete(TREATMENT_ENDPOINT, EXPERIMENT_1, TREATMENT_BAD).assertStatus(Status.NOT_FOUND);
 
         assertNotNull(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_1));
 
-        delete(TREATMENT_ENDPOINT, EXPERIMENT_1, EXP_1_TREATMENT_1)
-            .assertStatus(Status.NO_CONTENT);
+        delete(TREATMENT_ENDPOINT, EXPERIMENT_1, EXP_1_TREATMENT_1).assertStatus(Status.NO_CONTENT);
 
         assertNull(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_1));
     }
 
     @Test
     public void testUpdateTreatment() {
-        final UpdateTreatmentRequest request = new UpdateTreatmentRequest(Optional.of("new description"));
+        final UpdateTreatmentRequest request =
+                new UpdateTreatmentRequest(Optional.of("new description"));
 
         post(TREATMENT_ENDPOINT, EXPERIMENT_BAD, EXP_1_TREATMENT_1)
-            .entity(request)
-            .assertStatus(Status.NOT_FOUND);
+                .entity(request)
+                .assertStatus(Status.NOT_FOUND);
 
         post(TREATMENT_ENDPOINT, EXPERIMENT_1, TREATMENT_BAD)
-            .entity(request)
-            .assertStatus(Status.NOT_FOUND);
+                .entity(request)
+                .assertStatus(Status.NOT_FOUND);
 
         post(TREATMENT_ENDPOINT, EXPERIMENT_1, EXP_1_TREATMENT_1)
-            .entity(request)
-            .assertStatus(Status.NO_CONTENT);
+                .entity(request)
+                .assertStatus(Status.NO_CONTENT);
 
         final TreatmentDto treatment =
-            get(TREATMENT_ENDPOINT, EXPERIMENT_1, EXP_1_TREATMENT_1)
-                .assertStatus(Status.OK)
-                .result(TreatmentDto.class);
+                get(TREATMENT_ENDPOINT, EXPERIMENT_1, EXP_1_TREATMENT_1)
+                        .assertStatus(Status.OK)
+                        .result(TreatmentDto.class);
 
         assertEquals(request.getDescription().orElse(null), treatment.getDescription());
 
         final Iterable<AllocationDto> allocations =
-            get(ALLOCATIONS_ENDPOINT, EXPERIMENT_1)
-                .assertStatus(Status.OK)
-                .result(iterable(AllocationDto.class));
+                get(ALLOCATIONS_ENDPOINT, EXPERIMENT_1)
+                        .assertStatus(Status.OK)
+                        .result(iterable(AllocationDto.class));
 
         // Make sure we didn't lose our allocations for this treatment
         assertNotNull(
-            Iterables.find(allocations, new Predicate<AllocationDto>() {
-                @Override
-                public boolean apply(@Nullable AllocationDto input) {
-                    return input != null && input.getTreatment().equals(EXP_1_TREATMENT_1);
-                }
-            })
-        );
+                Iterables.find(
+                        allocations,
+                        new Predicate<AllocationDto>() {
+                            @Override
+                            public boolean apply(@Nullable AllocationDto input) {
+                                return input != null
+                                        && input.getTreatment().equals(EXP_1_TREATMENT_1);
+                            }
+                        }));
     }
 
     @Test
     public void testClearTreatments() {
-        delete(TREATMENTS_ENDPOINT, EXPERIMENT_BAD)
-            .assertStatus(Status.NOT_FOUND);
+        delete(TREATMENTS_ENDPOINT, EXPERIMENT_BAD).assertStatus(Status.NOT_FOUND);
 
         assertNotNull(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_1));
         assertNotNull(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_2));
         assertNotNull(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_3));
-        delete(TREATMENTS_ENDPOINT, EXPERIMENT_1)
-            .assertStatus(Status.NO_CONTENT);
+        delete(TREATMENTS_ENDPOINT, EXPERIMENT_1).assertStatus(Status.NO_CONTENT);
         assertNull(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_1));
         assertNull(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_2));
         assertNull(experiment(EXPERIMENT_1).getTreatment(EXP_1_TREATMENT_3));

--- a/alchemy-testing/src/main/java/io/rtr/alchemy/testing/db/ExperimentsStoreProviderTest.java
+++ b/alchemy-testing/src/main/java/io/rtr/alchemy/testing/db/ExperimentsStoreProviderTest.java
@@ -27,13 +27,14 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 /**
- * The purpose of this class is to provide a base class for testing whether an implementation of a provider
- * behaves correctly
+ * The purpose of this class is to provide a base class for testing whether an implementation of a
+ * provider behaves correctly
  */
 public abstract class ExperimentsStoreProviderTest {
     private Experiments experiments;
 
-    protected abstract ExperimentsStoreProvider createProvider() throws Exception ;
+    protected abstract ExperimentsStoreProvider createProvider() throws Exception;
+
     protected abstract void resetStore();
 
     @Attributes({"test"})
@@ -46,9 +47,7 @@ public abstract class ExperimentsStoreProviderTest {
 
         @Override
         public long computeHash(int seed, Set<String> hashAttributes, AttributesMap attributes) {
-            return identity(seed)
-                    .putString(name)
-                    .hash();
+            return identity(seed).putString(name).hash();
         }
 
         @Override
@@ -68,7 +67,9 @@ public abstract class ExperimentsStoreProviderTest {
     @Test
     public void testInitialState() {
         assertFalse("there should be no experiments yet", experiments.find().iterator().hasNext());
-        assertFalse("there should be no experiments yet", experiments.find(Filter.criteria().build()).iterator().hasNext());
+        assertFalse(
+                "there should be no experiments yet",
+                experiments.find(Filter.criteria().build()).iterator().hasNext());
     }
 
     @Test
@@ -80,18 +81,14 @@ public abstract class ExperimentsStoreProviderTest {
     public void testCreateExperiment() throws ValidationException {
         assertNull("should return null when experiment not found", experiments.get("foo"));
 
-        experiments
-            .create("foo")
-            .save();
+        experiments.create("foo").save();
 
         assertNotNull("did not find experiment", experiments.get("foo"));
     }
 
     @Test
-    public void testDeleteExperiment() throws ValidationException  {
-        experiments
-            .create("foo")
-            .save();
+    public void testDeleteExperiment() throws ValidationException {
+        experiments.create("foo").save();
 
         assertNotNull("did not find experiment", experiments.get("foo"));
 
@@ -102,49 +99,19 @@ public abstract class ExperimentsStoreProviderTest {
 
     @Test
     public void testFindExperimentFilterString() throws ValidationException {
-         experiments
-             .create("the_foo_experiment")
-             .setDescription("the bar description")
-             .save();
+        experiments.create("the_foo_experiment").setDescription("the bar description").save();
 
         assertFalse(
-            "should not have found experiment",
-            experiments
-                .find(
-                    Filter
-                        .criteria()
-                        .filter("control")
-                        .build()
-                )
-                .iterator()
-                .hasNext()
-        );
+                "should not have found experiment",
+                experiments.find(Filter.criteria().filter("control").build()).iterator().hasNext());
 
         assertTrue(
-            "should be able to filter by name substring",
-            experiments
-                .find(
-                    Filter
-                        .criteria()
-                        .filter("foo")
-                        .build()
-                )
-                .iterator()
-                .hasNext()
-        );
+                "should be able to filter by name substring",
+                experiments.find(Filter.criteria().filter("foo").build()).iterator().hasNext());
 
         assertTrue(
-            "should be able to filter by description substring",
-            experiments
-                .find(
-                    Filter
-                        .criteria()
-                        .filter("bar")
-                        .build()
-                )
-                .iterator()
-                .hasNext()
-        );
+                "should be able to filter by description substring",
+                experiments.find(Filter.criteria().filter("bar").build()).iterator().hasNext());
     }
 
     @Test
@@ -155,193 +122,109 @@ public abstract class ExperimentsStoreProviderTest {
 
         assertTrue("should have experiments", experiments.find().iterator().hasNext());
 
-        assertEquals(
-            3,
-            Iterables.size(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .build()
-                )
-            )
-        );
+        assertEquals(3, Iterables.size(experiments.find(Filter.criteria().build())));
+
+        assertEquals(2, Iterables.size(experiments.find(Filter.criteria().limit(2).build())));
+
+        assertEquals(2, Iterables.size(experiments.find(Filter.criteria().offset(1).build())));
 
         assertEquals(
-            2,
-            Iterables.size(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .limit(2)
-                        .build()
-                )
-            )
-        );
-
-        assertEquals(
-            2,
-            Iterables.size(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .offset(1)
-                        .build()
-                )
-            )
-        );
-
-        assertEquals(
-            1,
-            Iterables.size(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .offset(1)
-                        .limit(1)
-                        .build()
-                )
-            )
-        );
+                1, Iterables.size(experiments.find(Filter.criteria().offset(1).limit(1).build())));
     }
 
     @Test
-    public void testFindExperimentFilterOrdering() throws ValidationException  {
+    public void testFindExperimentFilterOrdering() throws ValidationException {
         final Experiment fooExp = experiments.create("foo").setDescription("a").save();
         final Experiment zooExp = experiments.create("zoo").setDescription("b").save();
         final Experiment barExp = experiments.create("bar").setDescription("c").save();
 
         assertTrue("should have experiments", experiments.find().iterator().hasNext());
 
-        assertEquals(
-            3,
-            Iterables.size(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .build()
-                )
-            )
-        );
+        assertEquals(3, Iterables.size(experiments.find(Filter.criteria().build())));
 
         assertEquals(
-            Lists.newArrayList(barExp, fooExp, zooExp),
-            Lists.newArrayList(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .ordering(
-                            Ordering
-                                .newBuilder()
-                                .orderBy(Ordering.Field.NAME)
-                                .build()
-                        )
-                        .build()
-                )
-            )
-        );
+                Lists.newArrayList(barExp, fooExp, zooExp),
+                Lists.newArrayList(
+                        experiments.find(
+                                Filter.criteria()
+                                        .ordering(
+                                                Ordering.newBuilder()
+                                                        .orderBy(Ordering.Field.NAME)
+                                                        .build())
+                                        .build())));
 
         assertEquals(
-            Lists.newArrayList(zooExp, fooExp, barExp),
-            Lists.newArrayList(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .ordering(
-                            Ordering
-                                .newBuilder()
-                                .orderBy(Ordering.Field.NAME, Ordering.Direction.DESCENDING)
-                                .build()
-                        )
-                        .build()
-                )
-            )
-        );
+                Lists.newArrayList(zooExp, fooExp, barExp),
+                Lists.newArrayList(
+                        experiments.find(
+                                Filter.criteria()
+                                        .ordering(
+                                                Ordering.newBuilder()
+                                                        .orderBy(
+                                                                Ordering.Field.NAME,
+                                                                Ordering.Direction.DESCENDING)
+                                                        .build())
+                                        .build())));
 
         assertEquals(
-            Lists.newArrayList(fooExp, zooExp, barExp),
-            Lists.newArrayList(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .ordering(
-                            Ordering
-                                .newBuilder()
-                                .orderBy(Ordering.Field.DESCRIPTION)
-                                .build()
-                        )
-                        .build()
-                )
-            )
-        );
+                Lists.newArrayList(fooExp, zooExp, barExp),
+                Lists.newArrayList(
+                        experiments.find(
+                                Filter.criteria()
+                                        .ordering(
+                                                Ordering.newBuilder()
+                                                        .orderBy(Ordering.Field.DESCRIPTION)
+                                                        .build())
+                                        .build())));
 
         assertEquals(
-            Lists.newArrayList(barExp, zooExp, fooExp),
-            Lists.newArrayList(
-                experiments.find(
-                    Filter
-                        .criteria()
-                        .ordering(
-                            Ordering
-                                .newBuilder()
-                                .orderBy(Ordering.Field.DESCRIPTION, Ordering.Direction.DESCENDING)
-                                .build()
-                        )
-                        .build()
-                )
-            )
-        );
+                Lists.newArrayList(barExp, zooExp, fooExp),
+                Lists.newArrayList(
+                        experiments.find(
+                                Filter.criteria()
+                                        .ordering(
+                                                Ordering.newBuilder()
+                                                        .orderBy(
+                                                                Ordering.Field.DESCRIPTION,
+                                                                Ordering.Direction.DESCENDING)
+                                                        .build())
+                                        .build())));
     }
 
     @Test
     public void testGetActiveTreatment() throws ValidationException {
         experiments
-            .create("foo")
-            .addTreatment("control")
-            .setHashAttributes()
-            .allocate("control", 100)
-            .save();
+                .create("foo")
+                .addTreatment("control")
+                .setHashAttributes()
+                .allocate("control", 100)
+                .save();
 
         assertNull(
-            "no active treatment should be returned for deactivated experiment",
-            experiments.getActiveTreatment(
-                "foo",
-                new TestIdentity("foo")
-            )
-        );
+                "no active treatment should be returned for deactivated experiment",
+                experiments.getActiveTreatment("foo", new TestIdentity("foo")));
 
-        experiments
-            .get("foo")
-            .activate()
-            .save();
+        experiments.get("foo").activate().save();
 
         final Identity identity = new TestIdentity("test");
 
         assertEquals(
-            "expected control treatment",
-            "control",
-            experiments.getActiveTreatment("foo", identity).getName()
-        );
+                "expected control treatment",
+                "control",
+                experiments.getActiveTreatment("foo", identity).getName());
 
-        experiments
-            .get("foo")
-            .setFilter(FilterExpression.of("test"))
-            .save();
+        experiments.get("foo").setFilter(FilterExpression.of("test")).save();
 
         assertEquals(
-            "expected control treatment",
-            "control",
-            experiments.getActiveTreatment("foo", identity).getName()
-        );
+                "expected control treatment",
+                "control",
+                experiments.getActiveTreatment("foo", identity).getName());
 
-        experiments
-            .get("foo")
-            .setFilter(FilterExpression.of("bar"))
-            .save();
+        experiments.get("foo").setFilter(FilterExpression.of("bar")).save();
 
         assertNull(
-            "no active treatment should be returned for experiment intended for different identity type",
-            experiments.getActiveTreatment("foo", identity)
-        );
+                "no active treatment should be returned for experiment intended for different identity type",
+                experiments.getActiveTreatment("foo", identity));
     }
 
     @Test
@@ -349,101 +232,93 @@ public abstract class ExperimentsStoreProviderTest {
         final Identity identity = new TestIdentity("test");
 
         experiments
-            .create("foo")
-            .addTreatment("control")
-            .allocate("control", 100)
-            .setFilter(FilterExpression.of("test"))
-            .save();
+                .create("foo")
+                .addTreatment("control")
+                .allocate("control", 100)
+                .setFilter(FilterExpression.of("test"))
+                .save();
 
         experiments
-            .create("bar")
-            .addTreatment("control")
-            .allocate("control", 100)
-            .setFilter(FilterExpression.of("test"))
-            .save();
+                .create("bar")
+                .addTreatment("control")
+                .allocate("control", 100)
+                .setFilter(FilterExpression.of("test"))
+                .save();
 
         assertTrue("no active experiments", experiments.getActiveTreatments(identity).isEmpty());
 
-        experiments
-            .get("foo")
-            .activate()
-            .save();
+        experiments.get("foo").activate().save();
 
-        assertEquals("should have one experiment", 1, experiments.getActiveTreatments(identity).size());
         assertEquals(
-            "wrong experiment",
-            "foo",
-            experiments.getActiveTreatments(identity).keySet().iterator().next().getName()
-        );
+                "should have one experiment", 1, experiments.getActiveTreatments(identity).size());
+        assertEquals(
+                "wrong experiment",
+                "foo",
+                experiments.getActiveTreatments(identity).keySet().iterator().next().getName());
 
-        experiments
-            .get("bar")
-            .activate()
-            .save();
+        experiments.get("bar").activate().save();
 
-        assertEquals("should have two experiments", 2, experiments.getActiveTreatments(identity).size());
+        assertEquals(
+                "should have two experiments", 2, experiments.getActiveTreatments(identity).size());
 
-        experiments
-            .get("bar")
-            .setFilter(FilterExpression.of("bar"))
-            .save();
+        experiments.get("bar").setFilter(FilterExpression.of("bar")).save();
 
-        assertEquals("should have one because of identity type", 1, experiments.getActiveTreatments(identity).size());
+        assertEquals(
+                "should have one because of identity type",
+                1,
+                experiments.getActiveTreatments(identity).size());
     }
 
     @Test
     public void testGetActiveExperiments() throws ValidationException {
-        experiments
-            .create("foo")
-            .save();
+        experiments.create("foo").save();
 
-        assertFalse("should have no active experiments", experiments.getActiveExperiments().iterator().hasNext());
+        assertFalse(
+                "should have no active experiments",
+                experiments.getActiveExperiments().iterator().hasNext());
 
-        experiments
-            .get("foo")
-            .activate()
-            .save();
+        experiments.get("foo").activate().save();
 
-        assertTrue("should have an active experiment", experiments.getActiveExperiments().iterator().hasNext());
+        assertTrue(
+                "should have an active experiment",
+                experiments.getActiveExperiments().iterator().hasNext());
     }
 
     @Test
     public void testExperimentObjectReference() throws ValidationException {
-        final Experiment obj1 = experiments
-            .create("foo")
-            .addTreatment("control")
-            .allocate("control", Allocations.NUM_BINS)
-            .activate()
-            .save();
+        final Experiment obj1 =
+                experiments
+                        .create("foo")
+                        .addTreatment("control")
+                        .allocate("control", Allocations.NUM_BINS)
+                        .activate()
+                        .save();
 
         final Experiment obj2 = experiments.get("foo");
 
         assertFalse(
-            "saved experiment object reference should not be same object reference from get()",
-            obj1 == obj2
-        );
+                "saved experiment object reference should not be same object reference from get()",
+                obj1 == obj2);
 
         final Experiment obj3 = experiments.find().iterator().next();
 
         assertFalse(
-            "saved experiment object reference should not be same object reference from find()",
-            obj1 == obj3
-        );
+                "saved experiment object reference should not be same object reference from find()",
+                obj1 == obj3);
 
         final Experiment obj4 = experiments.getActiveExperiments().iterator().next();
 
         assertFalse(
-            "saved experiment object reference should not be same object reference from getActiveExperiments()",
-            obj1 == obj4
-        );
+                "saved experiment object reference should not be same object reference from getActiveExperiments()",
+                obj1 == obj4);
 
         final Identity identity = mock(Identity.class);
         doReturn(AttributesMap.empty()).when(identity).computeAttributes();
-        final Experiment obj5 = experiments.getActiveTreatments(identity).keySet().iterator().next();
+        final Experiment obj5 =
+                experiments.getActiveTreatments(identity).keySet().iterator().next();
 
         assertFalse(
-            "saved experiment object reference should not be same object reference from getActiveTreatments()",
-            obj1 == obj5
-        );
+                "saved experiment object reference should not be same object reference from getActiveTreatments()",
+                obj1 == obj5);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,48 @@
 
         <!-- transitive test dependencies pinned to resolve conflicts -->
         <objenesis.version>1.1</objenesis.version>
+
+        <!-- plugin versions -->
+
+        <buildnumber-maven-plugin.version>3.2.0</buildnumber-maven-plugin.version>
+
+        <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
+
+        <fmt-maven-plugin.version>2.9.1</fmt-maven-plugin.version>
+
+        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+
+        <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
+
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+
+        <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
+
+        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+
+        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+
+        <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
+
+        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
+
+        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
+
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+
+        <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
+
+        <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
+
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+
+        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+
+        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+
+        <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -223,13 +265,6 @@
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
-
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
@@ -237,103 +272,289 @@
             <version>${equalsverifier.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.coveo</groupId>
+                    <artifactId>fmt-maven-plugin</artifactId>
+                    <version>${fmt-maven-plugin.version}</version>
+                    <configuration>
+                        <skipSortingImports>true</skipSortingImports>
+                        <style>aosp</style>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven-assembly-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin.version}</version>
+                    <configuration>
+                        <rules>
+                            <DependencyConvergence />
+                        </rules>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>enforce</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                    <configuration>
+                        <testSourceDirectory>src/integration-test/java</testSourceDirectory>
+                        <testClassesDirectory>${project.build.directory}/test-classes</testClassesDirectory>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven-gpg-plugin.version}</version>
+                    <configuration>
+                        <!-- Prevent `gpg` from using pinentry programs -->
+                        <gpgArguments>
+                            <arg>--pinentry-mode</arg>
+                            <arg>loopback</arg>
+                        </gpgArguments>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            </manifest>
+                            <manifestEntries>
+                                <!--suppress UnresolvedMavenProperty; supplied by buildnumber-maven-plugin -->
+                                <Implementation-Version>${buildNumber}</Implementation-Version>
+                                <Specification-Version>${project.version}</Specification-Version>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>${maven-release-plugin.version}</version>
+                    <configuration>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <mavenExecutorId>forked-path</mavenExecutorId>
+                        <tagNameFormat>v@{project.version}</tagNameFormat>
+                        <preparationGoals>clean test</preparationGoals>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-resources-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven-shade-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>${buildnumber-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <doCheck>false</doCheck>
+                        <doUpdate>false</doUpdate>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <version>${findbugs-maven-plugin.version}</version>
+                    <configuration>
+                        <effort>Max</effort>
+                        <threshold>Low</threshold>
+                        <xmlOutput>true</xmlOutput>
+                        <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
+                        <excludeFilterFile>findBugsExclusions.xml</excludeFilterFile>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>analyze-compile</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus-staging-maven-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>sonatype-nexus-staging</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <stagingProfileId>5db1fdef03b4db</stagingProfileId>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
+                </plugin>
+            </plugins>
         </pluginManagement>
 
         <plugins>
-            <!-- Release Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <tagNameFormat>v@{project.version}</tagNameFormat>
-                    <preparationGoals>clean test</preparationGoals>
-                </configuration>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
             </plugin>
-            <!-- Compiler Plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <!-- Enforcer Plugin -->
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <DependencyConvergence />
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
+                <version>${maven-enforcer-plugin.version}</version>
             </plugin>
-            <!-- Attach Source Plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Java Docs Plugin -->
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <version>${maven-javadoc-plugin.version}</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>${buildnumber-maven-plugin.version}</version>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
-                <configuration>
-                    <effort>Max</effort>
-                    <threshold>Low</threshold>
-                    <xmlOutput>true</xmlOutput>
-                    <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
-                    <excludeFilterFile>findBugsExclusions.xml</excludeFilterFile>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>analyze-compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <version>${findbugs-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -429,39 +650,17 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- Prevent `gpg` from using pinentry programs -->
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
-                            </execution>
-                        </executions>
+                        <version>${maven-gpg-plugin.version}</version>
                     </plugin>
+
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>${nexus-staging-maven-plugin.version}</version>
                         <extensions>true</extensions>
-                        <configuration>
-                            <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <stagingProfileId>5db1fdef03b4db</stagingProfileId>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,25 +27,59 @@
     </description>
 
     <properties>
-        <dropwizard.version>1.3.20</dropwizard.version>
-        <joda-time.version>2.10.5</joda-time.version>
-        <guava.version>22.0</guava.version>
-        <jersey.version>2.25.1</jersey.version>
-        <guice.version>4.1.0</guice.version>
-        <slf4j.version>1.7.6</slf4j.version>
-        <junit.version>4.13.1</junit.version>
-        <mockito.version>2.24.5</mockito.version>
-        <jackson.version>2.9.10</jackson.version>
-        <apache-math3.version>3.6</apache-math3.version>
-        <apache-lang.version>3.8.1</apache-lang.version>
+        <encoding>UTF-8</encoding>
+        <java.version>1.8</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
+
+        <!-- dependency versions -->
+
         <apache-httpclient.version>4.5.13</apache-httpclient.version>
-        <objenesis.version>1.1</objenesis.version>
-        <equalsverifier.version>1.4.1</equalsverifier.version>
-        <hamcrest.version>1.3</hamcrest.version>
+
+        <apache-math3.version>3.6</apache-math3.version>
+
+        <apache-lang.version>3.8.1</apache-lang.version>
+
+        <dropwizard.version>1.3.20</dropwizard.version>
+
         <findbugs.version>3.0.2</findbugs.version>
-        <nodep.version>2.2.2</nodep.version>
-        <javassist.version>3.24.1-GA</javassist.version>
+
+        <guava.version>22.0</guava.version>
+
         <hibernate-validator.version>5.4.3.Final</hibernate-validator.version>
+
+        <jackson.version>2.9.10</jackson.version>
+
+        <jersey.version>2.25.1</jersey.version>
+
+        <joda-time.version>2.10.5</joda-time.version>
+
+        <guice.version>4.1.0</guice.version>
+
+        <slf4j.version>1.7.6</slf4j.version>
+
+        <!-- transitive dependencies pinned to resolve conflicts -->
+
+        <cglib.version>2.2.2</cglib.version>
+
+        <!-- transitive dependencies pinned for security bumps or other issues -->
+
+        <javassist.version>3.24.1-GA</javassist.version>
+
+        <!-- test dependency versions -->
+
+        <equalsverifier.version>1.4.1</equalsverifier.version>
+
+        <hamcrest.version>1.3</hamcrest.version>
+
+        <junit.version>4.13.1</junit.version>
+
+        <mockito.version>2.24.5</mockito.version>
+
+        <!-- transitive test dependencies pinned to resolve conflicts -->
+        <objenesis.version>1.1</objenesis.version>
     </properties>
 
     <dependencyManagement>
@@ -173,7 +207,7 @@
             <dependency>
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
-                <version>${nodep.version}</version>
+                <version>${cglib.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -206,6 +240,10 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+
+        </pluginManagement>
+
         <plugins>
             <!-- Release Plugin -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -522,6 +522,12 @@
 
         <plugins>
             <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>${fmt-maven-plugin.version}</version>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>${maven-dependency-plugin.version}</version>


### PR DESCRIPTION
- Added `fmt-maven-plugin` config to enforce the format, and ran the formatter
- Bumped and pinned all the Maven plugins in use to latest (apart from the ANTLR plugin, see the comment on its version)
    - Put config into `<pluginManagement>` to ensure consistency across all types of runs
- Pinned all the default Maven plugins to latest

ANTLR itself is also bumped (plugin version should match the dependency), but it looks like the only resulting changes from that are Javadoc additions and alphabetical ordering of the methods.

**Testing**

Used this version with our live service locally &mdash; unit tests pass, as did a basic regression.