### PR TITLE
Build with Java 21 and use Testcontainers for MongoDB

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -22,17 +22,17 @@ jobs:
         with:
           yamllint_strict: true
 
-      - name: Set up JDK 8
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 21
           distribution: temurin
           check-latest: false
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5
         with:
-          maven-version: 3.9.4
+          maven-version: 3.9.5
 
       - name: Set up Nexus authentication and GPG passphrase
         uses: whelk-io/maven-settings-xml-action@v21

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,17 +28,17 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 21
           distribution: temurin
           check-latest: false
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5
         with:
-          maven-version: 3.9.4
+          maven-version: 3.9.5
 
       - name: Configure git
         run: |

--- a/alchemy-core/pom.xml
+++ b/alchemy-core/pom.xml
@@ -83,7 +83,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>com.coveo</groupId>
+          <groupId>com.spotify.fmt</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
           <version>${fmt-maven-plugin.version}</version>
           <configuration combine.self="append">

--- a/alchemy-db-mongo/pom.xml
+++ b/alchemy-db-mongo/pom.xml
@@ -84,8 +84,23 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mongodb</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/alchemy-db-mongo/src/test/java/io/rtr/alchemy/db/mongo/MongoStoreProviderTest.java
+++ b/alchemy-db-mongo/src/test/java/io/rtr/alchemy/db/mongo/MongoStoreProviderTest.java
@@ -1,20 +1,35 @@
 package io.rtr.alchemy.db.mongo;
 
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
+import com.mongodb.MongoCredential;
 import com.mongodb.MongoException;
 import io.rtr.alchemy.db.ExperimentsStoreProvider;
 import io.rtr.alchemy.testing.db.ExperimentsStoreProviderTest;
-import org.junit.Ignore;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.Assert.fail;
 
-@Ignore("must be run manually and requires a local Mongo instance")
+@Testcontainers
 public class MongoStoreProviderTest extends ExperimentsStoreProviderTest {
     private static final String DATABASE_NAME = "test_experiments";
 
+    @Container static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.4.14");
+
     @Override
     protected ExperimentsStoreProvider createProvider() {
-        return MongoStoreProvider.newBuilder().setDatabase(DATABASE_NAME).build();
+        final String connStr = mongoDBContainer.getReplicaSetUrl(DATABASE_NAME);
+        final MongoClientURI uri = new MongoClientURI(connStr, MongoClientOptions.builder());
+        MongoCredential credential =
+                MongoCredential.createCredential(
+                        uri.getUsername(), DATABASE_NAME, uri.getPassword());
+        return MongoStoreProvider.newBuilder()
+                .addCredential(credential)
+                .setDatabase(DATABASE_NAME)
+                .build();
     }
 
     @Override

--- a/alchemy-dependencies/pom.xml
+++ b/alchemy-dependencies/pom.xml
@@ -74,7 +74,11 @@
 
     <junit.version>4.13.1</junit.version>
 
+    <junit5.version>5.10.0</junit5.version>
+
     <mockito.version>2.24.5</mockito.version>
+
+    <testcontainers.version>1.19.1</testcontainers.version>
   </properties>
 
   <dependencyManagement>
@@ -226,10 +230,24 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit5.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- must be below all of the above so that they can be pinned before this tries to pull them in -->

--- a/alchemy-testing/pom.xml
+++ b/alchemy-testing/pom.xml
@@ -50,9 +50,8 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/alchemy-testing/src/main/java/io/rtr/alchemy/testing/db/ExperimentsStoreProviderTest.java
+++ b/alchemy-testing/src/main/java/io/rtr/alchemy/testing/db/ExperimentsStoreProviderTest.java
@@ -1,11 +1,11 @@
 package io.rtr.alchemy.testing.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -23,8 +23,8 @@ import io.rtr.alchemy.models.Allocations;
 import io.rtr.alchemy.models.Experiment;
 import io.rtr.alchemy.models.Experiments;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
@@ -60,45 +60,45 @@ public abstract class ExperimentsStoreProviderTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         resetStore();
         final ExperimentsStoreProvider provider = createProvider();
-        assertNotNull("provider cannot be null", provider);
+        assertNotNull(provider, "provider cannot be null");
         experiments = Experiments.using(provider).build();
     }
 
     @Test
     public void testInitialState() {
-        assertFalse("there should be no experiments yet", experiments.find().iterator().hasNext());
+        assertFalse(experiments.find().iterator().hasNext(), "there should be no experiments yet");
         assertFalse(
-                "there should be no experiments yet",
-                experiments.find(Filter.criteria().build()).iterator().hasNext());
+                experiments.find(Filter.criteria().build()).iterator().hasNext(),
+                "there should be no experiments yet");
     }
 
     @Test
     public void testGetReturnsNull() {
-        assertNull("should return null when experiment not found", experiments.get("foo"));
+        assertNull(experiments.get("foo"), "should return null when experiment not found");
     }
 
     @Test
     public void testCreateExperiment() throws ValidationException {
-        assertNull("should return null when experiment not found", experiments.get("foo"));
+        assertNull(experiments.get("foo"), "should return null when experiment not found");
 
         experiments.create("foo").save();
 
-        assertNotNull("did not find experiment", experiments.get("foo"));
+        assertNotNull(experiments.get("foo"), "did not find experiment");
     }
 
     @Test
     public void testDeleteExperiment() throws ValidationException {
         experiments.create("foo").save();
 
-        assertNotNull("did not find experiment", experiments.get("foo"));
+        assertNotNull(experiments.get("foo"), "did not find experiment");
 
         experiments.delete("foo");
 
-        assertNull("should return null when experiment not found", experiments.get("foo"));
+        assertNull(experiments.get("foo"), "should return null when experiment not found");
     }
 
     @Test
@@ -106,16 +106,16 @@ public abstract class ExperimentsStoreProviderTest {
         experiments.create("the_foo_experiment").setDescription("the bar description").save();
 
         assertFalse(
-                "should not have found experiment",
-                experiments.find(Filter.criteria().filter("control").build()).iterator().hasNext());
+                experiments.find(Filter.criteria().filter("control").build()).iterator().hasNext(),
+                "should not have found experiment");
 
         assertTrue(
-                "should be able to filter by name substring",
-                experiments.find(Filter.criteria().filter("foo").build()).iterator().hasNext());
+                experiments.find(Filter.criteria().filter("foo").build()).iterator().hasNext(),
+                "should be able to filter by name substring");
 
         assertTrue(
-                "should be able to filter by description substring",
-                experiments.find(Filter.criteria().filter("bar").build()).iterator().hasNext());
+                experiments.find(Filter.criteria().filter("bar").build()).iterator().hasNext(),
+                "should be able to filter by description substring");
     }
 
     @Test
@@ -124,7 +124,7 @@ public abstract class ExperimentsStoreProviderTest {
         experiments.create("exp2").save();
         experiments.create("exp3").save();
 
-        assertTrue("should have experiments", experiments.find().iterator().hasNext());
+        assertTrue(experiments.find().iterator().hasNext(), "should have experiments");
 
         assertEquals(3, Iterables.size(experiments.find(Filter.criteria().build())));
 
@@ -142,7 +142,7 @@ public abstract class ExperimentsStoreProviderTest {
         final Experiment zooExp = experiments.create("zoo").setDescription("b").save();
         final Experiment barExp = experiments.create("bar").setDescription("c").save();
 
-        assertTrue("should have experiments", experiments.find().iterator().hasNext());
+        assertTrue(experiments.find().iterator().hasNext(), "should have experiments");
 
         assertEquals(3, Iterables.size(experiments.find(Filter.criteria().build())));
 
@@ -205,30 +205,30 @@ public abstract class ExperimentsStoreProviderTest {
                 .save();
 
         assertNull(
-                "no active treatment should be returned for deactivated experiment",
-                experiments.getActiveTreatment("foo", new TestIdentity("foo")));
+                experiments.getActiveTreatment("foo", new TestIdentity("foo")),
+                "no active treatment should be returned for deactivated experiment");
 
         experiments.get("foo").activate().save();
 
         final Identity identity = new TestIdentity("test");
 
         assertEquals(
-                "expected control treatment",
                 "control",
-                experiments.getActiveTreatment("foo", identity).getName());
+                experiments.getActiveTreatment("foo", identity).getName(),
+                "expected control treatment");
 
         experiments.get("foo").setFilter(FilterExpression.of("test")).save();
 
         assertEquals(
-                "expected control treatment",
                 "control",
-                experiments.getActiveTreatment("foo", identity).getName());
+                experiments.getActiveTreatment("foo", identity).getName(),
+                "expected control treatment");
 
         experiments.get("foo").setFilter(FilterExpression.of("bar")).save();
 
         assertNull(
-                "no active treatment should be returned for experiment intended for different identity type",
-                experiments.getActiveTreatment("foo", identity));
+                experiments.getActiveTreatment("foo", identity),
+                "no active treatment should be returned for experiment intended for different identity type");
     }
 
     @Test
@@ -249,28 +249,28 @@ public abstract class ExperimentsStoreProviderTest {
                 .setFilter(FilterExpression.of("test"))
                 .save();
 
-        assertTrue("no active experiments", experiments.getActiveTreatments(identity).isEmpty());
+        assertTrue(experiments.getActiveTreatments(identity).isEmpty(), "no active experiments");
 
         experiments.get("foo").activate().save();
 
         assertEquals(
-                "should have one experiment", 1, experiments.getActiveTreatments(identity).size());
+                1, experiments.getActiveTreatments(identity).size(), "should have one experiment");
         assertEquals(
-                "wrong experiment",
                 "foo",
-                experiments.getActiveTreatments(identity).keySet().iterator().next().getName());
+                experiments.getActiveTreatments(identity).keySet().iterator().next().getName(),
+                "wrong experiment");
 
         experiments.get("bar").activate().save();
 
         assertEquals(
-                "should have two experiments", 2, experiments.getActiveTreatments(identity).size());
+                2, experiments.getActiveTreatments(identity).size(), "should have two experiments");
 
         experiments.get("bar").setFilter(FilterExpression.of("bar")).save();
 
         assertEquals(
-                "should have one because of identity type",
                 1,
-                experiments.getActiveTreatments(identity).size());
+                experiments.getActiveTreatments(identity).size(),
+                "should have one because of identity type");
     }
 
     @Test
@@ -278,14 +278,14 @@ public abstract class ExperimentsStoreProviderTest {
         experiments.create("foo").save();
 
         assertFalse(
-                "should have no active experiments",
-                experiments.getActiveExperiments().iterator().hasNext());
+                experiments.getActiveExperiments().iterator().hasNext(),
+                "should have no active experiments");
 
         experiments.get("foo").activate().save();
 
         assertTrue(
-                "should have an active experiment",
-                experiments.getActiveExperiments().iterator().hasNext());
+                experiments.getActiveExperiments().iterator().hasNext(),
+                "should have an active experiment");
     }
 
     @Test
@@ -301,23 +301,23 @@ public abstract class ExperimentsStoreProviderTest {
         final Experiment obj2 = experiments.get("foo");
 
         assertNotSame(
-                "saved experiment object reference should not be same object reference from get()",
                 obj1,
-                obj2);
+                obj2,
+                "saved experiment object reference should not be same object reference from get()");
 
         final Experiment obj3 = experiments.find().iterator().next();
 
         assertNotSame(
-                "saved experiment object reference should not be same object reference from find()",
                 obj1,
-                obj3);
+                obj3,
+                "saved experiment object reference should not be same object reference from find()");
 
         final Experiment obj4 = experiments.getActiveExperiments().iterator().next();
 
         assertNotSame(
-                "saved experiment object reference should not be same object reference from getActiveExperiments()",
                 obj1,
-                obj4);
+                obj4,
+                "saved experiment object reference should not be same object reference from getActiveExperiments()");
 
         final Identity identity = mock(Identity.class);
         doReturn(AttributesMap.empty()).when(identity).computeAttributes();
@@ -325,8 +325,8 @@ public abstract class ExperimentsStoreProviderTest {
                 experiments.getActiveTreatments(identity).keySet().iterator().next();
 
         assertNotSame(
-                "saved experiment object reference should not be same object reference from getActiveTreatments()",
                 obj1,
-                obj5);
+                obj5,
+                "saved experiment object reference should not be same object reference from getActiveTreatments()");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,8 @@
 
     <properties>
         <encoding>UTF-8</encoding>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <java.version>8</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
 
@@ -38,7 +37,7 @@
 
         <buildnumber-maven-plugin.version>3.2.0</buildnumber-maven-plugin.version>
 
-        <fmt-maven-plugin.version>2.9.1</fmt-maven-plugin.version>
+        <fmt-maven-plugin.version>2.21.1</fmt-maven-plugin.version>
 
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
 
@@ -81,7 +80,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>com.coveo</groupId>
+                    <groupId>com.spotify.fmt</groupId>
                     <artifactId>fmt-maven-plugin</artifactId>
                     <version>${fmt-maven-plugin.version}</version>
                     <configuration>
@@ -293,7 +292,7 @@
 
         <plugins>
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>${fmt-maven-plugin.version}</version>
             </plugin>


### PR DESCRIPTION
Also includes the use of JUnit 5 in `alchemy-testing`.

Note that artifacts still target Java 8, and may not work under later versions of Java (we need to upgrade Morphia to eliminate CGLib).